### PR TITLE
Fix Makefile error messages for missing ssl and invalid config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,9 @@ tests_binary := $(BUILD_DIR)/$(PACKAGE)
 docs_dir := build/$(PACKAGE)-docs
 
 ifdef config
-	ifeq (,$(filter $(config),debug release))
-		$(error Unknown configuration "$(config)")
-	endif
+  ifeq (,$(filter $(config),debug release))
+    $(error Unknown configuration "$(config)")
+  endif
 endif
 
 ifeq ($(config),release)
@@ -24,15 +24,15 @@ else
 endif
 
 ifeq (,$(filter $(MAKECMDGOALS),clean docs realclean TAGS))
-	ifeq ($(ssl), 3.0.x)
-		SSL = -Dopenssl_3.0.x
-	else ifeq ($(ssl), 1.1.x)
-		SSL = -Dopenssl_1.1.x
-	else ifeq ($(ssl), 0.9.0)
-		SSL = -Dopenssl_0.9.0
-	else
-		$(error Unknown SSL version "$(ssl)". Must set using 'ssl=FOO')
-	endif
+  ifeq ($(ssl), 3.0.x)
+    SSL = -Dopenssl_3.0.x
+  else ifeq ($(ssl), 1.1.x)
+    SSL = -Dopenssl_1.1.x
+  else ifeq ($(ssl), 0.9.0)
+    SSL = -Dopenssl_0.9.0
+  else
+    $(error Unknown SSL version "$(ssl)". Must set using 'ssl=FOO')
+  endif
 endif
 
 PONYC := $(PONYC) $(SSL)


### PR DESCRIPTION
## Summary

- Tab-indented `$(error)` calls inside conditional blocks were interpreted by Make as recipe lines, producing `recipe commences before first target` instead of the intended error messages
- Replaced tabs with spaces for conditional block indentation in both the `config` validation (line 16) and `ssl` validation (line 34) blocks

Closes #48