### PR TITLE
Add GetOrganizationRepositories

### DIFF
--- a/.release-notes/next-release.md
+++ b/.release-notes/next-release.md
@@ -19,3 +19,39 @@ primitive HandleResults
     end
 ```
 
+## Add GetOrganizationRepositories
+
+List all repositories in a GitHub organization with pagination support.
+
+```pony
+github.get_org_repos("ponylang").next[None]({
+  (result: (PaginatedList[Repository] | RequestError)) =>
+    match result
+    | let repos: PaginatedList[Repository] =>
+      for repo in repos.results.values() do
+        env.out.print(repo.full_name)
+      end
+    end
+})
+```
+
+## Make several Repository fields nullable to match GitHub API
+
+Several `Repository` fields are now nullable to match the GitHub API's actual response shape:
+- `network_count` and `subscribers_count`: `I64` → `(I64 | None)`
+- `description`, `homepage`, and `language`: `String` → `(String | None)`
+
+Code that accesses these fields directly will need to match on the union:
+
+Before:
+```pony
+env.out.print(repo.description)
+```
+
+After:
+```pony
+match repo.description
+| let d: String => env.out.print(d)
+end
+```
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,12 @@ All notable changes to this project will be documented in this file. This projec
 ### Added
 
 - Add pagination support to search results ([PR #50](https://github.com/ponylang/github_rest_api/pull/50))
+- Add GetOrganizationRepositories ([PR #52](https://github.com/ponylang/github_rest_api/pull/52))
 
 ### Changed
 
 - Update ponylang/peg dependency to 0.1.6 ([PR #42](https://github.com/ponylang/github_rest_api/pull/42))
+- Make several Repository fields nullable to match GitHub API ([PR #52](https://github.com/ponylang/github_rest_api/pull/52))
 
 ## [0.2.1] - 2025-07-16
 

--- a/examples/get-repository-oo/main.pony
+++ b/examples/get-repository-oo/main.pony
@@ -52,7 +52,9 @@ primitive PrintRepository
       out.print("Repository")
       out.print(repo.name)
       out.print(repo.full_name)
-      out.print(repo.description)
+      match repo.description
+      | let d: String => out.print(d)
+      end
       out.print(repo.html_url)
     | let e: RequestError =>
       out.print("Unable to retrieve repository")

--- a/examples/get-repository/main.pony
+++ b/examples/get-repository/main.pony
@@ -52,7 +52,9 @@ primitive PrintRepository
       out.print("Repository")
       out.print(repo.name)
       out.print(repo.full_name)
-      out.print(repo.description)
+      match repo.description
+      | let d: String => out.print(d)
+      end
       out.print(repo.html_url)
     | let e: RequestError =>
       out.print("Unable to retrieve repository")

--- a/github_rest_api/github.pony
+++ b/github_rest_api/github.pony
@@ -15,3 +15,8 @@ class val GitHub
   =>
     GetRepository(owner, repo, _creds)
 
+  fun get_org_repos(org: String)
+    : Promise[(PaginatedList[Repository] | RequestError)]
+  =>
+    GetOrganizationRepositories(org, _creds)
+


### PR DESCRIPTION
## Summary

- Add `GetOrganizationRepositories` primitive for paginated `GET /orgs/{org}/repos`
- Add `GitHub.get_org_repos()` convenience method
- Fix five `Repository` fields (`description`, `homepage`, `language`, `network_count`, `subscribers_count`) to use nullable types matching the GitHub API's actual response shape — the list endpoint returns null for `network_count`/`subscribers_count`, and both endpoints return null for `description`/`homepage`/`language` on some repos
- Update get-repository examples to handle nullable `description`

Part of the work identified in Discussion #45.