### PR TITLE
Fix always-true redirect status check in HTTP handlers

### DIFF
--- a/.release-notes/fix-redirect-status-check.md
+++ b/.release-notes/fix-redirect-status-check.md
@@ -1,0 +1,3 @@
+## Fix always-true redirect status check in HTTP handlers
+
+Fixed a logic bug where HTTP redirect responses could incorrectly be reported as errors.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -390,4 +390,3 @@ These API categories have zero coverage in the library:
 | CommitFile sparse | Only has sha, status, filename; missing additions, deletions, changes, patch |
 | No rate limiting | No handling of rate limit headers or 429 responses |
 | No conditional requests | No ETag/If-None-Match support |
-| HTTP error in redirects | `http_get.pony:108` has `(_status != 301) or (_status != 307)` which is always true (should be `and`) |

--- a/github_rest_api/paginated_list.pony
+++ b/github_rest_api/paginated_list.pony
@@ -233,6 +233,6 @@ class PaginatedJsonRequesterHandler[A: Any val] is HTTPHandler
       else
         _receiver.failure(_status, "", "Failed to parse response")
       end
-    elseif (_status != 301) or (_status != 307) then
+    elseif (_status != 301) and (_status != 307) then
       _receiver.failure(_status, consume y, "")
     end

--- a/github_rest_api/request/http_get.pony
+++ b/github_rest_api/request/http_get.pony
@@ -105,6 +105,6 @@ class JsonRequesterHandler is HTTPHandler
       else
         _receiver.failure(_status, "", "Failed to parse response")
       end
-    elseif (_status != 301) or (_status != 307) then
+    elseif (_status != 301) and (_status != 307) then
       _receiver.failure(_status, consume y, "")
     end


### PR DESCRIPTION
## Summary

The `finished()` method in both `JsonRequesterHandler` and `PaginatedJsonRequesterHandler` had `(_status != 301) or (_status != 307)`, which is always true. Changed `or` to `and` so redirect responses aren't incorrectly reported as errors.

Closes #47