### PR TITLE
Add GetRepositoryIssues with paginated issue listing

### DIFF
--- a/.release-notes/get-repository-issues.md
+++ b/.release-notes/get-repository-issues.md
@@ -1,0 +1,26 @@
+## Add GetRepositoryIssues with paginated issue listing
+
+List issues for a repository with pagination support. Supports filtering by label and state.
+
+```pony
+// Via Repository chaining
+github.get_repo("ponylang", "ponyc").next[None]({
+  (result: RepositoryOrError) =>
+    match result
+    | let repo: Repository =>
+      repo.get_issues(where labels = "discuss during sync").next[None]({
+        (r: (PaginatedList[Issue] | RequestError)) =>
+          match r
+          | let issues: PaginatedList[Issue] =>
+            for issue in issues.results.values() do
+              if not issue.is_pull_request then
+                env.out.print(issue.title)
+              end
+            end
+          end
+      })
+    end
+})
+```
+
+The `is_pull_request` field on `Issue` indicates whether an issue is actually a pull request, since the GitHub issues API returns both.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,9 +27,9 @@ Uses `corral` for dependency management. `make` automatically runs `corral fetch
 
 ```
 github_rest_api/
-  github.pony              -- GitHub class (entry point, only has get_repo)
+  github.pony              -- GitHub class (entry point, has get_repo and get_org_repos)
   repository.pony          -- Repository model + GetRepository, GetRepositoryLabels
-  issue.pony               -- Issue model + GetIssue
+  issue.pony               -- Issue model + GetIssue, GetRepositoryIssues
   pull_request.pony        -- PullRequest model + GetPullRequest
   pull_request_base.pony   -- PullRequestBase model (head/base refs)
   pull_request_file.pony   -- PullRequestFile model + GetPullRequestFiles
@@ -74,13 +74,14 @@ All API operations return `Promise[(T | RequestError)]`. The flow is:
 
 Models have methods that chain to further API calls:
 - `GitHub.get_repo(owner, repo)` -> `Repository`
-- `Repository.create_label(...)`, `.create_release(...)`, `.delete_label(...)`, `.get_commit(...)`, `.get_issue(...)`, `.get_pull_request(...)`
+- `GitHub.get_org_repos(org)` -> `PaginatedList[Repository]`
+- `Repository.create_label(...)`, `.create_release(...)`, `.delete_label(...)`, `.get_commit(...)`, `.get_issue(...)`, `.get_issues(...)`, `.get_pull_request(...)`
 - `Issue.create_comment(...)`, `.get_comments()`
 - `PullRequest.get_files()`
 
 ### Pagination
 
-`PaginatedList[A]` wraps an array of results with `prev_page()` / `next_page()` methods that return `(Promise | None)`. Pagination links are extracted from HTTP `Link` headers using the PEG-based `ExtractPaginationLinks` parser. Currently used by `GetRepositoryLabels`.
+`PaginatedList[A]` wraps an array of results with `prev_page()` / `next_page()` methods that return `(Promise | None)`. Pagination links are extracted from HTTP `Link` headers using the PEG-based `ExtractPaginationLinks` parser. Used by `GetRepositoryLabels`, `GetOrganizationRepositories`, and `GetRepositoryIssues`.
 
 ### Auth
 
@@ -114,7 +115,7 @@ commonly-used categories that a GitHub API library would typically need.
 | `/repos/{owner}/{repo}` | GET | GetRepository |
 | `/repos/{owner}/{repo}` | PATCH | **missing** |
 | `/repos/{owner}/{repo}` | DELETE | **missing** |
-| `/orgs/{org}/repos` | GET | **missing** |
+| `/orgs/{org}/repos` | GET | GetOrganizationRepositories |
 | `/orgs/{org}/repos` | POST | **missing** |
 | `/user/repos` | GET | **missing** |
 | `/user/repos` | POST | **missing** |
@@ -131,7 +132,7 @@ commonly-used categories that a GitHub API library would typically need.
 | Endpoint | Method | Library |
 |----------|--------|---------|
 | `/repos/{owner}/{repo}/issues/{number}` | GET | GetIssue |
-| `/repos/{owner}/{repo}/issues` | GET (list) | **missing** |
+| `/repos/{owner}/{repo}/issues` | GET (list) | GetRepositoryIssues |
 | `/repos/{owner}/{repo}/issues` | POST | **missing** |
 | `/repos/{owner}/{repo}/issues/{number}` | PATCH | **missing** |
 | `/repos/{owner}/{repo}/issues/{number}/lock` | PUT | **missing** |

--- a/github_rest_api/repository.pony
+++ b/github_rest_api/repository.pony
@@ -316,6 +316,21 @@ class val Repository
       Promise[IssueOrError].>apply(RequestError(where message' = e.message))
     end
 
+  fun get_issues(labels: String = "", state: String = "open")
+    : Promise[(PaginatedList[Issue] | RequestError)]
+  =>
+    let u = SimpleURITemplate(issues_url,
+      recover val Array[(String, String)] end)
+
+    match u
+    | let u': String =>
+      let issues_url' = GetRepositoryIssues._build_url(u', labels, state)
+      GetRepositoryIssues.by_url(issues_url', _creds)
+    | let e: ParseError =>
+      Promise[(PaginatedList[Issue] | RequestError)].>apply(
+        RequestError(where message' = e.message))
+    end
+
   fun get_pull_request(number: I64): Promise[PullRequestOrError] =>
       let u = SimpleURITemplate(
       pulls_url,


### PR DESCRIPTION
## Summary

- Adds `GetRepositoryIssues` primitive for paginated listing of repository issues via `GET /repos/{owner}/{repo}/issues`
- Supports `labels` and `state` query parameters for filtering
- Adds `is_pull_request: Bool` field to `Issue` model to distinguish issues from PRs in list results
- Adds `get_issues()` chaining method on `Repository`
- Updates CLAUDE.md coverage table and documentation

Originated from [Discussion #45](https://github.com/ponylang/github_rest_api/discussions/45) (pony-sync-helper gap analysis).

Related:
- [Discussion #54](https://github.com/ponylang/github_rest_api/discussions/54) — State parameter type design (String vs union type)
- [Discussion #55](https://github.com/ponylang/github_rest_api/discussions/55) — is_pull_request Bool vs richer type
- [Issue #56](https://github.com/ponylang/github_rest_api/issues/56) — Additional query parameters (sort, direction, since, per_page)