### PR TITLE
Add QueryParams for URL query string construction

### DIFF
--- a/.release-notes/next-release.md
+++ b/.release-notes/next-release.md
@@ -86,3 +86,18 @@ github.get_repo("ponylang", "ponyc").next[None]({
 
 The `is_pull_request` field on `Issue` indicates whether an issue is actually a pull request, since the GitHub issues API returns both.
 
+## Add QueryParams for building URL query strings
+
+Added a `QueryParams` primitive in the `request` package that builds URL query strings from key-value pairs with proper RFC 3986 percent-encoding.
+
+```pony
+let params = recover val
+  [("state", "open"); ("labels", "bug,enhancement")]
+end
+let query = QueryParams(params)
+// "?state=open&labels=bug%2Cenhancement"
+```
+
+## Fix missing URL encoding of query parameter values
+
+Query parameter values passed to `GetRepositoryIssues` and `Repository.get_issues()` are now properly percent-encoded. Previously, values containing special characters (spaces, `&`, `=`, etc.) would produce malformed URLs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,14 @@ All notable changes to this project will be documented in this file. This projec
 ### Fixed
 
 - Fix always-true redirect status check in HTTP handlers ([PR #53](https://github.com/ponylang/github_rest_api/pull/53))
+- Fix missing URL encoding of query parameter values in GetRepositoryIssues ([PR #59](https://github.com/ponylang/github_rest_api/pull/59))
 
 ### Added
 
 - Add pagination support to search results ([PR #50](https://github.com/ponylang/github_rest_api/pull/50))
 - Add GetOrganizationRepositories ([PR #52](https://github.com/ponylang/github_rest_api/pull/52))
 - Add GetRepositoryIssues with paginated issue listing ([PR #57](https://github.com/ponylang/github_rest_api/pull/57))
+- Add QueryParams for building URL query strings with percent-encoding ([PR #59](https://github.com/ponylang/github_rest_api/pull/59))
 
 ### Changed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,8 @@ github_rest_api/
     http_delete.pony       -- HTTPDelete (DELETE, expects 204)
     request_error.pony     -- RequestError (status, response_body, message)
     json.pony              -- JsonConverter interface
+    query_params.pony      -- QueryParams (URL query string builder with percent-encoding)
+    _test.pony             -- QueryParams tests (example + property-based)
   simple_uri_template/     -- RFC 6570 path segment expansion (PEG-based; temporary home, intended to be extracted to its own library)
   pagination_link_parser/  -- RFC 5988 Link header parser (PEG-based)
   _test.pony               -- Test runner (delegates to subpackage tests)

--- a/github_rest_api/_test.pony
+++ b/github_rest_api/_test.pony
@@ -1,5 +1,6 @@
 use "pony_test"
 use plp = "pagination_link_parser"
+use req = "request"
 use sut = "simple_uri_template"
 
 
@@ -12,4 +13,5 @@ actor \nodoc\ Main is TestList
 
   fun tag tests(test: PonyTest) =>
     plp.Tests.make().tests(test)
+    req.QueryParamsTests.make().tests(test)
     sut.Tests.make().tests(test)

--- a/github_rest_api/issue.pony
+++ b/github_rest_api/issue.pony
@@ -114,8 +114,15 @@ primitive GetRepositoryIssues
 
     match u
     | let u': String =>
-      let url = _build_url(u', labels, state)
-      by_url(url, creds)
+      let params = recover val
+        let p = Array[(String, String)]
+        p.push(("state", state))
+        if labels.size() > 0 then
+          p.push(("labels", labels))
+        end
+        p
+      end
+      by_url(u' + QueryParams(params), creds)
     | let e: ParseError =>
       Promise[(PaginatedList[Issue] | RequestError)].>apply(
         RequestError(where message' = e.message))
@@ -138,15 +145,6 @@ primitive GetRepositoryIssues
 
     p
 
-  fun _build_url(base: String, labels: String, state: String): String =>
-    let query = recover iso String end
-    query.append("?state=")
-    query.append(state)
-    if labels.size() > 0 then
-      query.append("&labels=")
-      query.append(labels)
-    end
-    base + consume query
 
 primitive IssueJsonConverter is JsonConverter[Issue]
   fun apply(json: JsonType val, creds: Credentials): Issue ? =>

--- a/github_rest_api/repository.pony
+++ b/github_rest_api/repository.pony
@@ -324,8 +324,15 @@ class val Repository
 
     match u
     | let u': String =>
-      let issues_url' = GetRepositoryIssues._build_url(u', labels, state)
-      GetRepositoryIssues.by_url(issues_url', _creds)
+      let params = recover val
+        let p = Array[(String, String)]
+        p.push(("state", state))
+        if labels.size() > 0 then
+          p.push(("labels", labels))
+        end
+        p
+      end
+      GetRepositoryIssues.by_url(u' + QueryParams(params), _creds)
     | let e: ParseError =>
       Promise[(PaginatedList[Issue] | RequestError)].>apply(
         RequestError(where message' = e.message))

--- a/github_rest_api/request/_test.pony
+++ b/github_rest_api/request/_test.pony
@@ -1,0 +1,158 @@
+use "collections"
+use "pony_check"
+use "pony_test"
+
+actor \nodoc\ QueryParamsTests is TestList
+  new create(env: Env) =>
+    PonyTest(env, this)
+
+  new make() =>
+    None
+
+  fun tag tests(test: PonyTest) =>
+    test(_TestQueryParamsEmpty)
+    test(_TestQueryParamsSingle)
+    test(_TestQueryParamsMultiple)
+    test(_TestQueryParamsSpaceEncoding)
+    test(_TestQueryParamsSpecialCharsEncoding)
+    test(_TestQueryParamsPercentEncoding)
+    test(_TestQueryParamsEmptyValue)
+    test(_TestQueryParamsKeyEncoding)
+    test(_TestQueryParamsUnreservedPassThrough)
+    test(_TestQueryParamsStructureProperty)
+    test(_TestQueryParamsEncodingProperty)
+    test(_TestQueryParamsPassThroughProperty)
+
+class \nodoc\ _TestQueryParamsEmpty is UnitTest
+  fun name(): String => "request/query-params/empty"
+
+  fun ref apply(h: TestHelper) =>
+    let params = recover val Array[(String, String)] end
+    h.assert_eq[String]("", QueryParams(params))
+
+class \nodoc\ _TestQueryParamsSingle is UnitTest
+  fun name(): String => "request/query-params/single"
+
+  fun ref apply(h: TestHelper) =>
+    let params = recover val [("state", "open")] end
+    h.assert_eq[String]("?state=open", QueryParams(params))
+
+class \nodoc\ _TestQueryParamsMultiple is UnitTest
+  fun name(): String => "request/query-params/multiple"
+
+  fun ref apply(h: TestHelper) =>
+    let params = recover val
+      [("state", "open"); ("labels", "bug")]
+    end
+    h.assert_eq[String]("?state=open&labels=bug", QueryParams(params))
+
+class \nodoc\ _TestQueryParamsSpaceEncoding is UnitTest
+  fun name(): String => "request/query-params/space-encoding"
+
+  fun ref apply(h: TestHelper) =>
+    let params = recover val [("q", "hello world")] end
+    h.assert_eq[String]("?q=hello%20world", QueryParams(params))
+
+class \nodoc\ _TestQueryParamsSpecialCharsEncoding is UnitTest
+  fun name(): String => "request/query-params/special-chars-encoding"
+
+  fun ref apply(h: TestHelper) =>
+    let params = recover val [("q", "a&b=c")] end
+    h.assert_eq[String]("?q=a%26b%3Dc", QueryParams(params))
+
+class \nodoc\ _TestQueryParamsPercentEncoding is UnitTest
+  fun name(): String => "request/query-params/percent-encoding"
+
+  fun ref apply(h: TestHelper) =>
+    let params = recover val [("q", "100%")] end
+    h.assert_eq[String]("?q=100%25", QueryParams(params))
+
+class \nodoc\ _TestQueryParamsEmptyValue is UnitTest
+  fun name(): String => "request/query-params/empty-value"
+
+  fun ref apply(h: TestHelper) =>
+    let params = recover val [("key", "")] end
+    h.assert_eq[String]("?key=", QueryParams(params))
+
+class \nodoc\ _TestQueryParamsKeyEncoding is UnitTest
+  fun name(): String => "request/query-params/key-encoding"
+
+  fun ref apply(h: TestHelper) =>
+    let params = recover val [("my key", "value")] end
+    h.assert_eq[String]("?my%20key=value", QueryParams(params))
+
+class \nodoc\ _TestQueryParamsUnreservedPassThrough is UnitTest
+  fun name(): String => "request/query-params/unreserved-pass-through"
+
+  fun ref apply(h: TestHelper) =>
+    let unreserved = "AZaz09-._~"
+    let params = recover val [("key", unreserved)] end
+    h.assert_eq[String]("?key=" + unreserved, QueryParams(params))
+
+class \nodoc\ _TestQueryParamsStructureProperty is UnitTest
+  fun name(): String => "request/query-params/structure-property"
+
+  fun ref apply(h: TestHelper) ? =>
+    PonyCheck.for_all[USize](
+      recover val Generators.usize(1, 10) end, h)(
+      {(n, h) =>
+        let params = recover val
+          let p = Array[(String, String)]
+          for i in Range(0, n) do
+            p.push(("k" + i.string(), "v" + i.string()))
+          end
+          p
+        end
+        let result = QueryParams(params)
+
+        // Must start with ?
+        try
+          h.assert_eq[U8]('?', result(0)?)
+        else
+          h.fail("Result is empty")
+        end
+
+        // Count & separators — should be n-1
+        var ampersand_count: USize = 0
+        for byte in result.values() do
+          if byte == '&' then ampersand_count = ampersand_count + 1 end
+        end
+        h.assert_eq[USize](n - 1, ampersand_count)
+      })?
+
+class \nodoc\ _TestQueryParamsEncodingProperty is UnitTest
+  fun name(): String => "request/query-params/encoding-property"
+
+  fun ref apply(h: TestHelper) ? =>
+    PonyCheck.for_all[String](
+      recover val Generators.ascii_printable(1, 30) end, h)(
+      {(value, h) =>
+        let v: String val = value.clone()
+        let params = recover val [("key", v)] end
+        let result = QueryParams(params)
+
+        // Extract value portion after "?key="
+        let encoded_value: String val = result.substring(5)
+
+        // Encoded value should not contain raw & = space or #
+        for byte in encoded_value.values() do
+          h.assert_true(byte != '&', "Raw & in encoded value")
+          h.assert_true(byte != '=', "Raw = in encoded value")
+          h.assert_true(byte != ' ', "Raw space in encoded value")
+          h.assert_true(byte != '#', "Raw # in encoded value")
+        end
+      })?
+
+class \nodoc\ _TestQueryParamsPassThroughProperty is UnitTest
+  fun name(): String => "request/query-params/pass-through-property"
+
+  fun ref apply(h: TestHelper) ? =>
+    PonyCheck.for_all[String](
+      recover val Generators.ascii_letters(1, 30) end, h)(
+      {(value, h) =>
+        let v: String val = value.clone()
+        let params = recover val [("key", v)] end
+        let result = QueryParams(params)
+        // Letters are unreserved, so value should pass through unchanged
+        h.assert_eq[String val]("?key=" + v, result)
+      })?

--- a/github_rest_api/request/query_params.pony
+++ b/github_rest_api/request/query_params.pony
@@ -1,0 +1,59 @@
+primitive QueryParams
+  """
+  Builds a URL query string from key-value pairs with RFC 3986
+  percent-encoding. Returns an empty string for an empty array, or
+  `"?key1=val1&key2=val2"` otherwise.
+
+  Both keys and values are encoded: only unreserved characters (A-Z, a-z,
+  0-9, `-`, `.`, `_`, `~`) pass through; everything else becomes `%XX`.
+  This includes characters like `&` and `=` that the http library's
+  `URLEncode` with `URLPartQuery` would leave unencoded.
+
+  ```pony
+  let params = recover val
+    [("state", "open"); ("labels", "bug")]
+  end
+  let query = QueryParams(params) // "?state=open&labels=bug"
+  ```
+  """
+
+  fun apply(params: Array[(String, String)] val): String val =>
+    if params.size() == 0 then
+      return ""
+    end
+
+    recover val
+      let query = String
+      var first = true
+      for (key, value) in params.values() do
+        if first then
+          query.append("?")
+          first = false
+        else
+          query.append("&")
+        end
+        _encode_into(query, key)
+        query.append("=")
+        _encode_into(query, value)
+      end
+      query
+    end
+
+  fun _encode_into(buf: String ref, value: String) =>
+    for byte in value.values() do
+      if _is_unreserved(byte) then
+        buf.push(byte)
+      else
+        buf.push('%')
+        let hi = (byte >> 4) and 0x0F
+        let lo = byte and 0x0F
+        buf.push(if hi < 10 then '0' + hi else 'A' + (hi - 10) end)
+        buf.push(if lo < 10 then '0' + lo else 'A' + (lo - 10) end)
+      end
+    end
+
+  fun _is_unreserved(byte: U8): Bool =>
+    ((byte >= 'A') and (byte <= 'Z')) or
+    ((byte >= 'a') and (byte <= 'z')) or
+    ((byte >= '0') and (byte <= '9')) or
+    (byte == '-') or (byte == '.') or (byte == '_') or (byte == '~')


### PR DESCRIPTION
## Summary

- Adds `QueryParams` primitive in the `request` package for building URL query strings with proper RFC 3986 percent-encoding
- Refactors `GetRepositoryIssues` and `Repository.get_issues()` to use `QueryParams` instead of manual string concatenation (which had no URL encoding)
- Includes 9 example-based tests and 3 PonyCheck property tests (first property-based tests in the project)

Addresses the "Query parameter support" item from discussion #45.