### PR TITLE
Qualify imports for request and simple_uri_template packages

### DIFF
--- a/github_rest_api/asset.pony
+++ b/github_rest_api/asset.pony
@@ -1,8 +1,8 @@
 use "json"
-use "request"
+use req = "request"
 
 class val Asset
-  let _creds: Credentials
+  let _creds: req.Credentials
 
   let id: I64
   let node_id: String
@@ -19,7 +19,7 @@ class val Asset
   let url: String
   let browser_download_url: String
 
-  new val create(creds: Credentials,
+  new val create(creds: req.Credentials,
     id': I64,
     node_id': String,
     name': String,
@@ -49,8 +49,8 @@ class val Asset
     url = url'
     browser_download_url = browser_download_url'
 
-primitive AssetJsonConverter is JsonConverter[Asset]
-  fun apply(json: JsonType val, creds: Credentials): Asset ? =>
+primitive AssetJsonConverter is req.JsonConverter[Asset]
+  fun apply(json: JsonType val, creds: req.Credentials): Asset ? =>
     let obj = JsonExtractor(json).as_object()?
     let id = JsonExtractor(obj("id")?).as_i64()?
     let node_id = JsonExtractor(obj("node_id")?).as_string()?

--- a/github_rest_api/commit_file.pony
+++ b/github_rest_api/commit_file.pony
@@ -1,14 +1,14 @@
 use "json"
 use "promises"
-use "request"
+use req = "request"
 
 class val CommitFile
-  let _creds: Credentials
+  let _creds: req.Credentials
   let sha: String
   let status: String
   let filename: String
 
-  new val create(creds: Credentials,
+  new val create(creds: req.Credentials,
     sha': String,
     status': String,
     filename': String)
@@ -18,9 +18,9 @@ class val CommitFile
     status = status'
     filename = filename'
 
-primitive CommitFileJsonConverter is JsonConverter[CommitFile]
+primitive CommitFileJsonConverter is req.JsonConverter[CommitFile]
   fun apply(json: JsonType val,
-    creds: Credentials): CommitFile ?
+    creds: req.Credentials): CommitFile ?
   =>
     let obj = JsonExtractor(json).as_object()?
     let sha = JsonExtractor(obj("sha")?).as_string()?

--- a/github_rest_api/git_commit.pony
+++ b/github_rest_api/git_commit.pony
@@ -1,14 +1,14 @@
 use "json"
-use "request"
+use req = "request"
 
 class val GitCommit
-  let _creds: Credentials
+  let _creds: req.Credentials
   let author: GitPerson
   let committer: GitPerson
   let message: String
   let url: String
 
-  new val create(creds: Credentials,
+  new val create(creds: req.Credentials,
     author': GitPerson,
     committer': GitPerson,
     message': String,
@@ -20,8 +20,8 @@ class val GitCommit
     message = message'
     url = url'
 
-primitive GitCommitJsonConverter is JsonConverter[GitCommit]
-  fun apply(json: JsonType val, creds: Credentials): GitCommit ? =>
+primitive GitCommitJsonConverter is req.JsonConverter[GitCommit]
+  fun apply(json: JsonType val, creds: req.Credentials): GitCommit ? =>
     let obj = JsonExtractor(json).as_object()?
     let author = GitPersonJsonConverter(obj("author")?, creds)?
     let committer = GitPersonJsonConverter(obj("committer")?, creds)?

--- a/github_rest_api/git_person.pony
+++ b/github_rest_api/git_person.pony
@@ -1,5 +1,5 @@
 use "json"
-use "request"
+use req = "request"
 
 class val GitPerson
   let name: String
@@ -9,8 +9,8 @@ class val GitPerson
     name = name'
     email = email'
 
-primitive GitPersonJsonConverter is JsonConverter[GitPerson]
-  fun apply(json: JsonType val, creds: Credentials): GitPerson ? =>
+primitive GitPersonJsonConverter is req.JsonConverter[GitPerson]
+  fun apply(json: JsonType val, creds: req.Credentials): GitPerson ? =>
     let obj = JsonExtractor(json).as_object()?
     let name = JsonExtractor(obj("name")?).as_string()?
     let email = JsonExtractor(obj("email")?).as_string()?

--- a/github_rest_api/github.pony
+++ b/github_rest_api/github.pony
@@ -1,13 +1,13 @@
 use "net"
 use "promises"
-use "request"
+use req = "request"
 
-type RepositoryOrError is (Repository | RequestError)
+type RepositoryOrError is (Repository | req.RequestError)
 
 class val GitHub
-  let _creds: Credentials
+  let _creds: req.Credentials
 
-  new val create(creds: Credentials) =>
+  new val create(creds: req.Credentials) =>
     _creds = creds
 
   fun get_repo(owner: String, repo: String)
@@ -16,7 +16,7 @@ class val GitHub
     GetRepository(owner, repo, _creds)
 
   fun get_org_repos(org: String)
-    : Promise[(PaginatedList[Repository] | RequestError)]
+    : Promise[(PaginatedList[Repository] | req.RequestError)]
   =>
     GetOrganizationRepositories(org, _creds)
 

--- a/github_rest_api/license.pony
+++ b/github_rest_api/license.pony
@@ -1,15 +1,15 @@
 use "json"
-use "request"
+use req = "request"
 
 class val License
-  let _creds: Credentials
+  let _creds: req.Credentials
   let node_id: String
   let name: String
   let key: String
   let spdx_id: String
   let url: String
 
-  new val create(creds: Credentials,
+  new val create(creds: req.Credentials,
     node_id': String,
     name': String,
     key': String,
@@ -23,8 +23,8 @@ class val License
     spdx_id = spdx_id'
     url = url'
 
-primitive LicenseJsonConverter is JsonConverter[License]
-  fun apply(json: JsonType val, creds: Credentials): License ? =>
+primitive LicenseJsonConverter is req.JsonConverter[License]
+  fun apply(json: JsonType val, creds: req.Credentials): License ? =>
     let obj = JsonExtractor(json).as_object()?
     let node_id = JsonExtractor(obj("node_id")?).as_string()?
     let name = JsonExtractor(obj("name")?).as_string()?

--- a/github_rest_api/pull_request_base.pony
+++ b/github_rest_api/pull_request_base.pony
@@ -1,15 +1,15 @@
 use "json"
-use "request"
+use req = "request"
 
 class val PullRequestBase
-  let _creds: Credentials
+  let _creds: req.Credentials
   let label: String
   let reference: String
   let sha: String
   let user: User
   let repo: Repository
 
-  new val create(creds: Credentials,
+  new val create(creds: req.Credentials,
     label': String,
     reference': String,
     sha': String,
@@ -23,8 +23,8 @@ class val PullRequestBase
     user = user'
     repo = repo'
 
-primitive PullRequestBaseJsonConverter is JsonConverter[PullRequestBase]
-  fun apply(json: JsonType val, creds: Credentials): PullRequestBase ? =>
+primitive PullRequestBaseJsonConverter is req.JsonConverter[PullRequestBase]
+  fun apply(json: JsonType val, creds: req.Credentials): PullRequestBase ? =>
     let obj = JsonExtractor(json).as_object()?
     let label = JsonExtractor(obj("label")?).as_string()?
     let reference = JsonExtractor(obj("ref")?).as_string()?

--- a/github_rest_api/pull_request_file.pony
+++ b/github_rest_api/pull_request_file.pony
@@ -1,17 +1,17 @@
 use "json"
 use "net"
 use "promises"
-use "request"
-use "simple_uri_template"
+use req = "request"
+use sut = "simple_uri_template"
 
 type PullRequestFiles is Array[PullRequestFile] val
-type PullRequestFilesOrError is (PullRequestFiles | RequestError)
+type PullRequestFilesOrError is (PullRequestFiles | req.RequestError)
 
 class val PullRequestFile
-  let _creds: Credentials
+  let _creds: req.Credentials
   let filename: String
 
-  new val create(creds: Credentials, filename': String) =>
+  new val create(creds: req.Credentials, filename': String) =>
     _creds = creds
     filename = filename'
 
@@ -19,9 +19,9 @@ primitive GetPullRequestFiles
   fun apply(owner: String,
     repo: String,
     number: I64,
-    creds: Credentials): Promise[PullRequestFilesOrError]
+    creds: req.Credentials): Promise[PullRequestFilesOrError]
   =>
-    let u = SimpleURITemplate(
+    let u = sut.SimpleURITemplate(
       recover val
         "https://api.github.com/repos{/owner}{/repo}/pulls{/number}/files"
       end,
@@ -32,35 +32,35 @@ primitive GetPullRequestFiles
     match u
     | let u': String =>
       by_url(u', creds)
-    | let e: ParseError =>
+    | let e: sut.ParseError =>
       Promise[PullRequestFilesOrError].>apply(
-        RequestError(where message' = e.message))
+        req.RequestError(where message' = e.message))
     end
 
   fun by_url(url: String,
-    creds: Credentials): Promise[PullRequestFilesOrError]
+    creds: req.Credentials): Promise[PullRequestFilesOrError]
   =>
     let p = Promise[PullRequestFilesOrError]
-    let r = ResultReceiver[PullRequestFiles](creds,
+    let r = req.ResultReceiver[PullRequestFiles](creds,
       p,
       PullRequestFilesJsonConverter)
 
     try
-      JsonRequester(creds.auth)(url, r)?
+      req.JsonRequester(creds.auth)(url, r)?
     else
       let m = recover val
         "Unable to initiate get_files request to" + url
       end
 
-      p(RequestError(where message' = m))
+      p(req.RequestError(where message' = m))
     end
 
     p
 
 primitive PullRequestFilesJsonConverter is
-  JsonConverter[Array[PullRequestFile] val]
+  req.JsonConverter[Array[PullRequestFile] val]
   fun apply(json: JsonType val,
-    creds: Credentials): Array[PullRequestFile] val ?
+    creds: req.Credentials): Array[PullRequestFile] val ?
   =>
     let files = recover trn Array[PullRequestFile] end
 

--- a/github_rest_api/user.pony
+++ b/github_rest_api/user.pony
@@ -1,8 +1,8 @@
 use "json"
-use "request"
+use req = "request"
 
 class val User
-  let _creds: Credentials
+  let _creds: req.Credentials
   let login: String
   let id: I64
   let node_id: String
@@ -22,7 +22,7 @@ class val User
   let user_type: String
   let site_admin: Bool
 
-  new val create(creds: Credentials,
+  new val create(creds: req.Credentials,
     login': String,
     id': I64,
     node_id': String,
@@ -62,8 +62,8 @@ class val User
     user_type = user_type'
     site_admin = site_admin'
 
-primitive UserJsonConverter is JsonConverter[User]
-  fun apply(json: JsonType val, creds: Credentials): User ? =>
+primitive UserJsonConverter is req.JsonConverter[User]
+  fun apply(json: JsonType val, creds: req.Credentials): User ? =>
     let obj = JsonExtractor(json).as_object()?
     let login = JsonExtractor(obj("login")?).as_string()?
     let id = JsonExtractor(obj("id")?).as_i64()?


### PR DESCRIPTION
## Summary

- Converts unqualified `use "request"` and `use "simple_uri_template"` imports to aliased forms (`use req = "request"`, `use sut = "simple_uri_template"`) across all 18 production files
- Qualifies all type references from those packages with `req.` or `sut.` prefixes
- Makes production code consistent with the test runner convention, avoiding potential name collisions

Closes #60