### PR TITLE
Add IssuePullRequest model on Issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,13 @@ All notable changes to this project will be documented in this file. This projec
 - Add GetOrganizationRepositories ([PR #52](https://github.com/ponylang/github_rest_api/pull/52))
 - Add GetRepositoryIssues with paginated issue listing ([PR #57](https://github.com/ponylang/github_rest_api/pull/57))
 - Add QueryParams for building URL query strings with percent-encoding ([PR #59](https://github.com/ponylang/github_rest_api/pull/59))
+- Add IssuePullRequest model for pull request metadata on issues ([PR #62](https://github.com/ponylang/github_rest_api/pull/62))
 
 ### Changed
 
 - Update ponylang/peg dependency to 0.1.6 ([PR #42](https://github.com/ponylang/github_rest_api/pull/42))
 - Make several Repository fields nullable to match GitHub API ([PR #52](https://github.com/ponylang/github_rest_api/pull/52))
+- Replace `is_pull_request: Bool` with `pull_request: (IssuePullRequest | None)` on Issue ([PR #62](https://github.com/ponylang/github_rest_api/pull/62))
 
 ## [0.2.1] - 2025-07-16
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,7 @@ github_rest_api/
   github.pony              -- GitHub class (entry point, has get_repo and get_org_repos)
   repository.pony          -- Repository model + GetRepository, GetRepositoryLabels
   issue.pony               -- Issue model + GetIssue, GetRepositoryIssues
+  issue_pull_request.pony  -- IssuePullRequest model (PR metadata on issues)
   pull_request.pony        -- PullRequest model + GetPullRequest
   pull_request_base.pony   -- PullRequestBase model (head/base refs)
   pull_request_file.pony   -- PullRequestFile model + GetPullRequestFiles

--- a/github_rest_api/issue.pony
+++ b/github_rest_api/issue.pony
@@ -16,7 +16,7 @@ class val Issue
   let state: (String | None)
   let body: (String | None)
 
-  let is_pull_request: Bool
+  let pull_request: (IssuePullRequest | None)
 
   let url: String
   let respository_url: String
@@ -38,7 +38,7 @@ class val Issue
     labels': Array[Label] val,
     state': (String | None),
     body': (String | None),
-    is_pull_request': Bool = false)
+    pull_request': (IssuePullRequest | None) = None)
   =>
     _creds = creds
     url = url'
@@ -53,7 +53,7 @@ class val Issue
     labels = labels'
     state = state'
     body = body'
-    is_pull_request = is_pull_request'
+    pull_request = pull_request'
 
   fun create_comment(comment: String): Promise[IssueCommentOrError] =>
     CreateIssueComment.by_url(comments_url, comment, _creds)
@@ -169,7 +169,12 @@ primitive IssueJsonConverter is req.JsonConverter[Issue]
       labels.push(l)
     end
 
-    let is_pull_request = obj.contains("pull_request")
+    let pull_request =
+      if obj.contains("pull_request") then
+        IssuePullRequestJsonConverter(obj("pull_request")?, creds)?
+      else
+        None
+      end
 
     Issue(creds,
       url,
@@ -184,4 +189,4 @@ primitive IssueJsonConverter is req.JsonConverter[Issue]
       consume labels,
       state,
       body,
-      is_pull_request)
+      pull_request)

--- a/github_rest_api/issue_pull_request.pony
+++ b/github_rest_api/issue_pull_request.pony
@@ -1,0 +1,40 @@
+use "json"
+use req = "request"
+
+class val IssuePullRequest
+  """
+  Pull request metadata present on issues that are actually pull requests.
+
+  When listing issues via the GitHub REST API, pull requests are included in
+  the results. Each pull request has a `pull_request` sub-object containing
+  URLs and merge status. This class captures that sub-object, allowing callers
+  to both distinguish PRs from true issues and access PR-specific URLs.
+  """
+  let url: String
+  let html_url: String
+  let diff_url: String
+  let patch_url: String
+  let merged_at: (String | None)
+
+  new val create(url': String,
+    html_url': String,
+    diff_url': String,
+    patch_url': String,
+    merged_at': (String | None))
+  =>
+    url = url'
+    html_url = html_url'
+    diff_url = diff_url'
+    patch_url = patch_url'
+    merged_at = merged_at'
+
+primitive IssuePullRequestJsonConverter is req.JsonConverter[IssuePullRequest]
+  fun apply(json: JsonType val, creds: req.Credentials): IssuePullRequest ? =>
+    let obj = JsonExtractor(json).as_object()?
+    let url = JsonExtractor(obj("url")?).as_string()?
+    let html_url = JsonExtractor(obj("html_url")?).as_string()?
+    let diff_url = JsonExtractor(obj("diff_url")?).as_string()?
+    let patch_url = JsonExtractor(obj("patch_url")?).as_string()?
+    let merged_at = JsonExtractor(obj("merged_at")?).as_string_or_none()?
+
+    IssuePullRequest(url, html_url, diff_url, patch_url, merged_at)


### PR DESCRIPTION
## Summary

- Add `IssuePullRequest` class that captures the `pull_request` sub-object from GitHub's issues API (url, html_url, diff_url, patch_url, merged_at)
- Replace `is_pull_request: Bool` on `Issue` with `pull_request: (IssuePullRequest | None)` — callers can both distinguish PRs from true issues and access PR-specific URLs/merge status
- Breaking change: code using `issue.is_pull_request` must switch to matching on `issue.pull_request`

Motivated by [Discussion #45](https://github.com/ponylang/github_rest_api/discussions/45).