### PR TITLE
Pass auth token on GET requests

### DIFF
--- a/.release-notes/fix-get-auth-token.md
+++ b/.release-notes/fix-get-auth-token.md
@@ -1,0 +1,3 @@
+## Fix GET requests not sending authentication token
+
+All GET-based API operations were making unauthenticated requests, limiting rate limits to 60 requests/hour instead of 5,000 and preventing access to private repositories. GET requests now correctly send the authentication token when one is provided via `Credentials`.

--- a/github_rest_api/commit.pony
+++ b/github_rest_api/commit.pony
@@ -56,7 +56,7 @@ primitive GetCommit
     let receiver = req.ResultReceiver[Commit](creds, p, CommitJsonConverter)
 
     try
-      req.JsonRequester(creds.auth)(url, receiver)?
+      req.JsonRequester(creds)(url, receiver)?
     else
       let m = recover val
         "Unable to initiate get commit request to" + url

--- a/github_rest_api/issue.pony
+++ b/github_rest_api/issue.pony
@@ -87,7 +87,7 @@ primitive GetIssue
     let receiver = req.ResultReceiver[Issue](creds, p, IssueJsonConverter)
 
     try
-      req.JsonRequester(creds.auth)(url, receiver)?
+      req.JsonRequester(creds)(url, receiver)?
     else
       let m = recover val
         "Unable to initiate get_issue request to" + url
@@ -137,7 +137,7 @@ primitive GetRepositoryIssues
     let r = PaginatedResultReceiver[Issue](creds, p, plc)
 
     try
-      PaginatedJsonRequester(creds.auth).apply[Issue](url, r)?
+      PaginatedJsonRequester(creds).apply[Issue](url, r)?
     else
       let m = "Unable to initiate get_repository_issues request to " + url
       p(req.RequestError(where message' = consume m))

--- a/github_rest_api/issue_comment.pony
+++ b/github_rest_api/issue_comment.pony
@@ -93,7 +93,7 @@ primitive GetIssueComments
       IssueCommentsJsonConverter)
 
     try
-      req.JsonRequester(creds.auth)(url, r)?
+      req.JsonRequester(creds)(url, r)?
     else
       let m = recover val
         "Unable to initiate get_comments request to" + url

--- a/github_rest_api/pull_request.pony
+++ b/github_rest_api/pull_request.pony
@@ -75,7 +75,7 @@ primitive GetPullRequest
       PullRequestJsonConverter)
 
     try
-      req.JsonRequester(creds.auth)(url, r)?
+      req.JsonRequester(creds)(url, r)?
     else
       let m = recover val
         "Unable to initiate get_pull_request request to" + url

--- a/github_rest_api/pull_request_file.pony
+++ b/github_rest_api/pull_request_file.pony
@@ -46,7 +46,7 @@ primitive GetPullRequestFiles
       PullRequestFilesJsonConverter)
 
     try
-      req.JsonRequester(creds.auth)(url, r)?
+      req.JsonRequester(creds)(url, r)?
     else
       let m = recover val
         "Unable to initiate get_files request to" + url

--- a/github_rest_api/repository.pony
+++ b/github_rest_api/repository.pony
@@ -379,7 +379,7 @@ primitive GetRepository
       RepositoryJsonConverter)
 
     try
-      req.JsonRequester(creds.auth)(url, r)?
+      req.JsonRequester(creds)(url, r)?
     else
       let m = "Unable to initiate get_repo request to " + url
       p(req.RequestError(where message' = consume m))
@@ -417,7 +417,7 @@ primitive GetRepositoryLabels
     let r = PaginatedResultReceiver[Label](creds, p, plc)
 
     try
-      PaginatedJsonRequester(creds.auth).apply[Label](url, r)?
+      PaginatedJsonRequester(creds).apply[Label](url, r)?
     else
       let m = "Unable to initiate get_repo request to " + url
       p(req.RequestError(where message' = consume m))
@@ -454,7 +454,7 @@ primitive GetOrganizationRepositories
     let r = PaginatedResultReceiver[Repository](creds, p, plc)
 
     try
-      PaginatedJsonRequester(creds.auth).apply[Repository](url, r)?
+      PaginatedJsonRequester(creds).apply[Repository](url, r)?
     else
       let m = "Unable to initiate get_org_repos request to " + url
       p(req.RequestError(where message' = consume m))


### PR DESCRIPTION
## Summary

- GET-based API operations (`JsonRequester`, `PaginatedJsonRequester`, `SearchJsonRequester`) were making unauthenticated requests because they never passed the token to `RequestFactory`, limiting rate to 60 req/hr and blocking private repo access
- Thread `Credentials` through the requester and handler factory chain so `RequestFactory` receives the token, matching what POST and DELETE already do

Closes #63