### PR TITLE
Add full Gist API support

### DIFF
--- a/.release-notes/add-gist-api-support.md
+++ b/.release-notes/add-gist-api-support.md
@@ -1,0 +1,36 @@
+## Add full Gist API support
+
+Complete coverage of the GitHub Gist API: 15 gist operations and 5 gist comment operations covering CRUD, listing, forking, commit history, and starring.
+
+New models: `Gist`, `GistFile`, `GistFileEdit`, `GistFileRename`, `GistFileDelete`, `GistCommit`, `GistChangeStatus`, and `GistComment`.
+
+```pony
+// Fetch a gist
+GitHub(creds).get_gist("abc123")
+  .next[None]({(r: GistOrError) =>
+    match r
+    | let gist: Gist =>
+      for (name, file) in gist.files.values() do
+        env.out.print(name)
+      end
+      // Chain to further operations
+      gist.get_comments()
+      gist.star()
+      gist.fork()
+    end
+  })
+
+// Create a gist
+let files = recover val [("hello.py", "print('hello')")] end
+CreateGist(files, creds where description = "My gist", is_public = true)
+
+// Update a gist's files
+let updates = recover val
+  [("old.py", GistFileEdit("new content"))
+   ("rename.py", GistFileRename("renamed.py"))
+   ("delete-me.py", GistFileDelete)]
+end
+gist.update_gist(updates)
+```
+
+This also adds three new HTTP infrastructure classes: `HTTPPatch` (PATCH with JSON response), `HTTPPut` (PUT expecting 204), and `HTTPCheck` (GET returning Bool based on status code 204/404).

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,73 @@
+# Examples
+
+Examples come in two styles: **functional** (calling operation primitives directly) and **OO** (chaining through `GitHub` and model convenience methods). Both styles produce the same results; use whichever fits your application's structure.
+
+Each example has its own `Makefile`. Build with `make ssl=3.0.x` (or the SSL version matching your system).
+
+## Gists
+
+| Example | Style | Description |
+|---------|-------|-------------|
+| `get-gist` | Functional | Fetch a gist by ID and print its files |
+| `get-gist-oo` | OO | Same as `get-gist`, using `GitHub.get_gist()` |
+| `create-gist` | Functional | Create a new gist with a single file |
+| `create-gist-oo` | OO | Same as `create-gist`, using `GitHub.create_gist()` |
+| `list-gists` | Functional | List the authenticated user's gists with pagination |
+| `list-gists-oo` | OO | Same as `list-gists`, using `GitHub.get_user_gists()` |
+| `gist-comments` | Functional | List comments on a gist with pagination |
+| `gist-comments-oo` | OO | Same as `gist-comments`, chaining through `Gist.get_comments()` |
+| `star-gist` | Functional | Star a gist and verify it is starred |
+| `star-gist-oo` | OO | Same as `star-gist`, chaining through `Gist.star()` |
+
+## Repositories
+
+| Example | Style | Description |
+|---------|-------|-------------|
+| `get-repository` | Functional | Fetch a repository by owner and name |
+| `get-repository-oo` | OO | Same as `get-repository`, using `GitHub.get_repo()` |
+| `get-repository-labels` | Functional | List labels for a repository with pagination |
+
+## Issues
+
+| Example | Style | Description |
+|---------|-------|-------------|
+| `get-issue` | Functional | Fetch an issue by number |
+| `get-issue-oo` | OO | Same as `get-issue`, chaining through `Repository.get_issue()` |
+| `get-issue-comments` | Functional | List comments on an issue |
+| `get-issue-comments-oo` | OO | Same as `get-issue-comments`, chaining through `Issue.get_comments()` |
+| `create-issue-comment` | Functional | Create a comment on an issue |
+| `create-issue-comment-oo` | OO | Same as `create-issue-comment`, chaining through `Issue.create_comment()` |
+| `search-issues` | Functional | Search issues across repositories with pagination |
+
+## Pull Requests
+
+| Example | Style | Description |
+|---------|-------|-------------|
+| `get-pull-request` | Functional | Fetch a pull request by number |
+| `get-pull-request-oo` | OO | Same as `get-pull-request`, chaining through `Repository.get_pull_request()` |
+| `get-pull-request-files` | Functional | List files changed in a pull request |
+| `get-pull-request-files-oo` | OO | Same as `get-pull-request-files`, chaining through `PullRequest.get_files()` |
+
+## Commits
+
+| Example | Style | Description |
+|---------|-------|-------------|
+| `get-commit` | Functional | Fetch a commit by SHA |
+| `get-commit-oo` | OO | Same as `get-commit`, chaining through `Repository.get_commit()` |
+
+## Labels
+
+| Example | Style | Description |
+|---------|-------|-------------|
+| `create-label` | Functional | Create a label on a repository |
+| `create-label-oo` | OO | Same as `create-label`, chaining through `Repository.create_label()` |
+| `delete-label` | Functional | Delete a label from a repository |
+| `delete-label-oo` | OO | Same as `delete-label`, chaining through `Repository.delete_label()` |
+| `standard-pony-labels` | Functional | Creates the standard set of labels used by ponylang projects |
+
+## Releases
+
+| Example | Style | Description |
+|---------|-------|-------------|
+| `create-release` | Functional | Create a release on a repository |
+| `create-release-oo` | OO | Same as `create-release`, chaining through `Repository.create_release()` |

--- a/examples/create-gist-oo/Makefile
+++ b/examples/create-gist-oo/Makefile
@@ -1,0 +1,35 @@
+GET_DEPENDENCIES_WITH := corral fetch
+COMPILE_WITH := corral run -- ponyc
+
+BUILD_DIR ?= build
+SRC_DIR := .
+BINARY_NAME := create-gist-oo
+LIB_SRC := ../../github_rest_api/
+
+PONYC = $(COMPILE_WITH)
+
+ifeq ($(ssl), 3.0.x)
+	SSL = -Dopenssl_3.0.x
+else ifeq ($(ssl), 1.1.x)
+	SSL = -Dopenssl_1.1.x
+else ifeq ($(ssl), 0.9.0)
+	SSL = -Dopenssl_0.9.0
+else
+	$(error Unknown SSL version "$(ssl)". Must set using 'ssl=FOO')
+endif
+
+PONYC := $(PONYC) $(SSL)
+
+SOURCE_FILES := $(shell find $(LIB_SRC) -name "*.pony")
+
+$(BUILD_DIR)/$(BINARY_NAME): $(SOURCE_FILES) main.pony | $(BUILD_DIR)
+	$(GET_DEPENDENCIES_WITH)
+	$(PONYC) -o $(BUILD_DIR) $(SRC_DIR)
+
+clean:
+	rm -rf $(BUILD_DIR)
+
+$(BUILD_DIR):
+	mkdir -p $(BUILD_DIR)
+
+.PHONY: clean

--- a/examples/create-gist-oo/main.pony
+++ b/examples/create-gist-oo/main.pony
@@ -1,0 +1,74 @@
+use "../../github_rest_api"
+use "../../github_rest_api/request"
+use "cli"
+use "net"
+
+actor Main
+  new create(env: Env) =>
+    try
+      // ----- CLI setup
+      let cs =
+        CommandSpec.leaf("create-gist-oo",
+          "Create a new gist with a single file",
+          [
+            OptionSpec.string("filename", "Name of the file to create")
+            OptionSpec.string("content", "Content of the file")
+            OptionSpec.string("description",
+              "Description of the gist"
+              where default' = "")
+            OptionSpec.bool("public",
+              "Whether the gist should be public"
+              where default' = false)
+            OptionSpec.string("token", "GitHub personal access token")
+          ]
+        )? .> add_help()?
+
+      let cmd = match CommandParser(cs).parse(env.args, env.vars)
+      | let c: Command =>
+        c
+      | let ch: CommandHelp =>
+        ch.print_help(env.out)
+        return
+      | let se: SyntaxError =>
+        env.err.print(se.string())
+        env.exitcode(1)
+        return
+      end
+
+      let filename = cmd.option("filename").string()
+      let content = cmd.option("content").string()
+      let description = cmd.option("description").string()
+      let is_public = cmd.option("public").bool()
+      let token = cmd.option("token").string()
+
+      // ----- Create gist
+      let auth = TCPConnectAuth(env.root)
+      let creds = Credentials(auth, token)
+
+      let files = recover val
+        let f = Array[(String, String)]
+        f.push((filename, content))
+        f
+      end
+
+      let desc: (String | None) =
+        if description.size() > 0 then description else None end
+
+      GitHub(creds).create_gist(files, desc, is_public)
+        .next[None](PrintGist~apply(env.out))
+    else
+      env.out.print("Something went wrong")
+    end
+
+primitive PrintGist
+  fun apply(out: OutStream, g: GistOrError) =>
+    match g
+    | let gist: Gist =>
+      out.print("Gist created: " + gist.id)
+      out.print(gist.html_url)
+    | let e: RequestError =>
+      out.print("Unable to create gist")
+      out.print(e.status.string())
+      out.print(e.response_body)
+      out.print(e.message)
+    end

--- a/examples/create-gist/Makefile
+++ b/examples/create-gist/Makefile
@@ -1,0 +1,35 @@
+GET_DEPENDENCIES_WITH := corral fetch
+COMPILE_WITH := corral run -- ponyc
+
+BUILD_DIR ?= build
+SRC_DIR := .
+BINARY_NAME := create-gist
+LIB_SRC := ../../github_rest_api/
+
+PONYC = $(COMPILE_WITH)
+
+ifeq ($(ssl), 3.0.x)
+	SSL = -Dopenssl_3.0.x
+else ifeq ($(ssl), 1.1.x)
+	SSL = -Dopenssl_1.1.x
+else ifeq ($(ssl), 0.9.0)
+	SSL = -Dopenssl_0.9.0
+else
+	$(error Unknown SSL version "$(ssl)". Must set using 'ssl=FOO')
+endif
+
+PONYC := $(PONYC) $(SSL)
+
+SOURCE_FILES := $(shell find $(LIB_SRC) -name "*.pony")
+
+$(BUILD_DIR)/$(BINARY_NAME): $(SOURCE_FILES) main.pony | $(BUILD_DIR)
+	$(GET_DEPENDENCIES_WITH)
+	$(PONYC) -o $(BUILD_DIR) $(SRC_DIR)
+
+clean:
+	rm -rf $(BUILD_DIR)
+
+$(BUILD_DIR):
+	mkdir -p $(BUILD_DIR)
+
+.PHONY: clean

--- a/examples/create-gist/main.pony
+++ b/examples/create-gist/main.pony
@@ -1,0 +1,74 @@
+use "../../github_rest_api"
+use "../../github_rest_api/request"
+use "cli"
+use "net"
+
+actor Main
+  new create(env: Env) =>
+    try
+      // ----- CLI setup
+      let cs =
+        CommandSpec.leaf("create-gist",
+          "Create a new gist with a single file",
+          [
+            OptionSpec.string("filename", "Name of the file to create")
+            OptionSpec.string("content", "Content of the file")
+            OptionSpec.string("description",
+              "Description of the gist"
+              where default' = "")
+            OptionSpec.bool("public",
+              "Whether the gist should be public"
+              where default' = false)
+            OptionSpec.string("token", "GitHub personal access token")
+          ]
+        )? .> add_help()?
+
+      let cmd = match CommandParser(cs).parse(env.args, env.vars)
+      | let c: Command =>
+        c
+      | let ch: CommandHelp =>
+        ch.print_help(env.out)
+        return
+      | let se: SyntaxError =>
+        env.err.print(se.string())
+        env.exitcode(1)
+        return
+      end
+
+      let filename = cmd.option("filename").string()
+      let content = cmd.option("content").string()
+      let description = cmd.option("description").string()
+      let is_public = cmd.option("public").bool()
+      let token = cmd.option("token").string()
+
+      // ----- Create gist
+      let auth = TCPConnectAuth(env.root)
+      let creds = Credentials(auth, token)
+
+      let files = recover val
+        let f = Array[(String, String)]
+        f.push((filename, content))
+        f
+      end
+
+      let desc: (String | None) =
+        if description.size() > 0 then description else None end
+
+      let p = CreateGist(files, creds, desc, is_public)
+      p.next[None](PrintGist~apply(env.out))
+    else
+      env.out.print("Something went wrong")
+    end
+
+primitive PrintGist
+  fun apply(out: OutStream, g: GistOrError) =>
+    match g
+    | let gist: Gist =>
+      out.print("Gist created: " + gist.id)
+      out.print(gist.html_url)
+    | let e: RequestError =>
+      out.print("Unable to create gist")
+      out.print(e.status.string())
+      out.print(e.response_body)
+      out.print(e.message)
+    end

--- a/examples/get-gist-oo/Makefile
+++ b/examples/get-gist-oo/Makefile
@@ -1,0 +1,35 @@
+GET_DEPENDENCIES_WITH := corral fetch
+COMPILE_WITH := corral run -- ponyc
+
+BUILD_DIR ?= build
+SRC_DIR := .
+BINARY_NAME := get-gist-oo
+LIB_SRC := ../../github_rest_api/
+
+PONYC = $(COMPILE_WITH)
+
+ifeq ($(ssl), 3.0.x)
+	SSL = -Dopenssl_3.0.x
+else ifeq ($(ssl), 1.1.x)
+	SSL = -Dopenssl_1.1.x
+else ifeq ($(ssl), 0.9.0)
+	SSL = -Dopenssl_0.9.0
+else
+	$(error Unknown SSL version "$(ssl)". Must set using 'ssl=FOO')
+endif
+
+PONYC := $(PONYC) $(SSL)
+
+SOURCE_FILES := $(shell find $(LIB_SRC) -name "*.pony")
+
+$(BUILD_DIR)/$(BINARY_NAME): $(SOURCE_FILES) main.pony | $(BUILD_DIR)
+	$(GET_DEPENDENCIES_WITH)
+	$(PONYC) -o $(BUILD_DIR) $(SRC_DIR)
+
+clean:
+	rm -rf $(BUILD_DIR)
+
+$(BUILD_DIR):
+	mkdir -p $(BUILD_DIR)
+
+.PHONY: clean

--- a/examples/get-gist-oo/main.pony
+++ b/examples/get-gist-oo/main.pony
@@ -1,0 +1,65 @@
+use "../../github_rest_api"
+use "../../github_rest_api/request"
+use "cli"
+use "net"
+
+actor Main
+  new create(env: Env) =>
+    try
+      // ----- CLI setup
+      let cs =
+        CommandSpec.leaf("get-gist-oo",
+          "Get information about a gist",
+          [
+            OptionSpec.string("gist-id", "ID of the gist to fetch")
+            OptionSpec.string("token",
+              "GitHub personal access token"
+              where default' = "")
+          ]
+        )? .> add_help()?
+
+      let cmd = match CommandParser(cs).parse(env.args, env.vars)
+      | let c: Command =>
+        c
+      | let ch: CommandHelp =>
+        ch.print_help(env.out)
+        return
+      | let se: SyntaxError =>
+        env.err.print(se.string())
+        env.exitcode(1)
+        return
+      end
+
+      let gist_id = cmd.option("gist-id").string()
+      let token = cmd.option("token").string()
+
+      // ----- Get gist
+      let auth = TCPConnectAuth(env.root)
+      let creds = Credentials(auth, token)
+
+      GitHub(creds).get_gist(gist_id)
+        .next[None](PrintGist~apply(env.out))
+    else
+      env.out.print("Something went wrong")
+    end
+
+primitive PrintGist
+  fun apply(out: OutStream, g: GistOrError) =>
+    match g
+    | let gist: Gist =>
+      out.print("Gist: " + gist.id)
+      match gist.description
+      | let d: String => out.print("Description: " + d)
+      end
+      out.print("Public: " + gist.public.string())
+      out.print("Files:")
+      for (name, file) in gist.files.values() do
+        out.print("  " + name + " (" + file.size.string() + " bytes)")
+      end
+      out.print(gist.html_url)
+    | let e: RequestError =>
+      out.print("Unable to retrieve gist")
+      out.print(e.status.string())
+      out.print(e.response_body)
+      out.print(e.message)
+    end

--- a/examples/get-gist/Makefile
+++ b/examples/get-gist/Makefile
@@ -1,0 +1,35 @@
+GET_DEPENDENCIES_WITH := corral fetch
+COMPILE_WITH := corral run -- ponyc
+
+BUILD_DIR ?= build
+SRC_DIR := .
+BINARY_NAME := get-gist
+LIB_SRC := ../../github_rest_api/
+
+PONYC = $(COMPILE_WITH)
+
+ifeq ($(ssl), 3.0.x)
+	SSL = -Dopenssl_3.0.x
+else ifeq ($(ssl), 1.1.x)
+	SSL = -Dopenssl_1.1.x
+else ifeq ($(ssl), 0.9.0)
+	SSL = -Dopenssl_0.9.0
+else
+	$(error Unknown SSL version "$(ssl)". Must set using 'ssl=FOO')
+endif
+
+PONYC := $(PONYC) $(SSL)
+
+SOURCE_FILES := $(shell find $(LIB_SRC) -name "*.pony")
+
+$(BUILD_DIR)/$(BINARY_NAME): $(SOURCE_FILES) main.pony | $(BUILD_DIR)
+	$(GET_DEPENDENCIES_WITH)
+	$(PONYC) -o $(BUILD_DIR) $(SRC_DIR)
+
+clean:
+	rm -rf $(BUILD_DIR)
+
+$(BUILD_DIR):
+	mkdir -p $(BUILD_DIR)
+
+.PHONY: clean

--- a/examples/get-gist/main.pony
+++ b/examples/get-gist/main.pony
@@ -1,0 +1,65 @@
+use "../../github_rest_api"
+use "../../github_rest_api/request"
+use "cli"
+use "net"
+
+actor Main
+  new create(env: Env) =>
+    try
+      // ----- CLI setup
+      let cs =
+        CommandSpec.leaf("get-gist",
+          "Get information about a gist",
+          [
+            OptionSpec.string("gist-id", "ID of the gist to fetch")
+            OptionSpec.string("token",
+              "GitHub personal access token"
+              where default' = "")
+          ]
+        )? .> add_help()?
+
+      let cmd = match CommandParser(cs).parse(env.args, env.vars)
+      | let c: Command =>
+        c
+      | let ch: CommandHelp =>
+        ch.print_help(env.out)
+        return
+      | let se: SyntaxError =>
+        env.err.print(se.string())
+        env.exitcode(1)
+        return
+      end
+
+      let gist_id = cmd.option("gist-id").string()
+      let token = cmd.option("token").string()
+
+      // ----- Get gist
+      let auth = TCPConnectAuth(env.root)
+      let creds = Credentials(auth, token)
+
+      let p = GetGist(gist_id, creds)
+      p.next[None](PrintGist~apply(env.out))
+    else
+      env.out.print("Something went wrong")
+    end
+
+primitive PrintGist
+  fun apply(out: OutStream, g: GistOrError) =>
+    match g
+    | let gist: Gist =>
+      out.print("Gist: " + gist.id)
+      match gist.description
+      | let d: String => out.print("Description: " + d)
+      end
+      out.print("Public: " + gist.public.string())
+      out.print("Files:")
+      for (name, file) in gist.files.values() do
+        out.print("  " + name + " (" + file.size.string() + " bytes)")
+      end
+      out.print(gist.html_url)
+    | let e: RequestError =>
+      out.print("Unable to retrieve gist")
+      out.print(e.status.string())
+      out.print(e.response_body)
+      out.print(e.message)
+    end

--- a/examples/gist-comments-oo/Makefile
+++ b/examples/gist-comments-oo/Makefile
@@ -1,0 +1,35 @@
+GET_DEPENDENCIES_WITH := corral fetch
+COMPILE_WITH := corral run -- ponyc
+
+BUILD_DIR ?= build
+SRC_DIR := .
+BINARY_NAME := gist-comments-oo
+LIB_SRC := ../../github_rest_api/
+
+PONYC = $(COMPILE_WITH)
+
+ifeq ($(ssl), 3.0.x)
+	SSL = -Dopenssl_3.0.x
+else ifeq ($(ssl), 1.1.x)
+	SSL = -Dopenssl_1.1.x
+else ifeq ($(ssl), 0.9.0)
+	SSL = -Dopenssl_0.9.0
+else
+	$(error Unknown SSL version "$(ssl)". Must set using 'ssl=FOO')
+endif
+
+PONYC := $(PONYC) $(SSL)
+
+SOURCE_FILES := $(shell find $(LIB_SRC) -name "*.pony")
+
+$(BUILD_DIR)/$(BINARY_NAME): $(SOURCE_FILES) main.pony | $(BUILD_DIR)
+	$(GET_DEPENDENCIES_WITH)
+	$(PONYC) -o $(BUILD_DIR) $(SRC_DIR)
+
+clean:
+	rm -rf $(BUILD_DIR)
+
+$(BUILD_DIR):
+	mkdir -p $(BUILD_DIR)
+
+.PHONY: clean

--- a/examples/gist-comments-oo/main.pony
+++ b/examples/gist-comments-oo/main.pony
@@ -1,0 +1,82 @@
+use "../../github_rest_api"
+use "../../github_rest_api/request"
+use "cli"
+use "net"
+use "promises"
+
+actor Main
+  new create(env: Env) =>
+    try
+      // ----- CLI setup
+      let cs =
+        CommandSpec.leaf("gist-comments-oo",
+          "List comments on a gist",
+          [
+            OptionSpec.string("gist-id", "ID of the gist")
+            OptionSpec.string("token",
+              "GitHub personal access token"
+              where default' = "")
+          ]
+        )? .> add_help()?
+
+      let cmd = match CommandParser(cs).parse(env.args, env.vars)
+      | let c: Command =>
+        c
+      | let ch: CommandHelp =>
+        ch.print_help(env.out)
+        return
+      | let se: SyntaxError =>
+        env.err.print(se.string())
+        env.exitcode(1)
+        return
+      end
+
+      let gist_id = cmd.option("gist-id").string()
+      let token = cmd.option("token").string()
+
+      // ----- Get gist comments via OO API
+      let auth = TCPConnectAuth(env.root)
+      let creds = Credentials(auth, token)
+
+      GitHub(creds).get_gist(gist_id)
+        .flatten_next[(PaginatedList[GistComment] | RequestError)](
+          RetrieveComments~apply())
+        .next[None](PrintComments~apply(env.out))
+    else
+      env.out.print("Something went wrong")
+    end
+
+primitive RetrieveComments
+  fun apply(g: GistOrError)
+    : Promise[(PaginatedList[GistComment] | RequestError)]
+  =>
+    match g
+    | let gist: Gist =>
+      gist.get_comments()
+    | let e: RequestError =>
+      Promise[(PaginatedList[GistComment] | RequestError)].>apply(e)
+    end
+
+primitive PrintComments
+  fun apply(out: OutStream,
+    r: (PaginatedList[GistComment] | RequestError))
+  =>
+    match r
+    | let list: PaginatedList[GistComment] =>
+      for c in list.results.values() do
+        out.print("Comment #" + c.id.string() + " ==>")
+        out.print(c.body)
+        out.print("")
+      end
+      match list.next_page()
+      | let promise: Promise[(PaginatedList[GistComment] | RequestError)] =>
+        promise.next[None](PrintComments~apply(out))
+      else
+        out.print("------- No more comments")
+      end
+    | let e: RequestError =>
+      out.print("Unable to retrieve gist comments")
+      out.print(e.status.string())
+      out.print(e.response_body)
+      out.print(e.message)
+    end

--- a/examples/gist-comments/Makefile
+++ b/examples/gist-comments/Makefile
@@ -1,0 +1,35 @@
+GET_DEPENDENCIES_WITH := corral fetch
+COMPILE_WITH := corral run -- ponyc
+
+BUILD_DIR ?= build
+SRC_DIR := .
+BINARY_NAME := gist-comments
+LIB_SRC := ../../github_rest_api/
+
+PONYC = $(COMPILE_WITH)
+
+ifeq ($(ssl), 3.0.x)
+	SSL = -Dopenssl_3.0.x
+else ifeq ($(ssl), 1.1.x)
+	SSL = -Dopenssl_1.1.x
+else ifeq ($(ssl), 0.9.0)
+	SSL = -Dopenssl_0.9.0
+else
+	$(error Unknown SSL version "$(ssl)". Must set using 'ssl=FOO')
+endif
+
+PONYC := $(PONYC) $(SSL)
+
+SOURCE_FILES := $(shell find $(LIB_SRC) -name "*.pony")
+
+$(BUILD_DIR)/$(BINARY_NAME): $(SOURCE_FILES) main.pony | $(BUILD_DIR)
+	$(GET_DEPENDENCIES_WITH)
+	$(PONYC) -o $(BUILD_DIR) $(SRC_DIR)
+
+clean:
+	rm -rf $(BUILD_DIR)
+
+$(BUILD_DIR):
+	mkdir -p $(BUILD_DIR)
+
+.PHONY: clean

--- a/examples/gist-comments/main.pony
+++ b/examples/gist-comments/main.pony
@@ -1,0 +1,69 @@
+use "../../github_rest_api"
+use "../../github_rest_api/request"
+use "cli"
+use "net"
+use "promises"
+
+actor Main
+  new create(env: Env) =>
+    try
+      // ----- CLI setup
+      let cs =
+        CommandSpec.leaf("gist-comments",
+          "List comments on a gist",
+          [
+            OptionSpec.string("gist-id", "ID of the gist")
+            OptionSpec.string("token",
+              "GitHub personal access token"
+              where default' = "")
+          ]
+        )? .> add_help()?
+
+      let cmd = match CommandParser(cs).parse(env.args, env.vars)
+      | let c: Command =>
+        c
+      | let ch: CommandHelp =>
+        ch.print_help(env.out)
+        return
+      | let se: SyntaxError =>
+        env.err.print(se.string())
+        env.exitcode(1)
+        return
+      end
+
+      let gist_id = cmd.option("gist-id").string()
+      let token = cmd.option("token").string()
+
+      // ----- Get gist comments
+      let auth = TCPConnectAuth(env.root)
+      let creds = Credentials(auth, token)
+
+      let p = GetGistComments(gist_id, creds)
+      p.next[None](PrintComments~apply(env.out))
+    else
+      env.out.print("Something went wrong")
+    end
+
+primitive PrintComments
+  fun apply(out: OutStream,
+    r: (PaginatedList[GistComment] | RequestError))
+  =>
+    match r
+    | let list: PaginatedList[GistComment] =>
+      for c in list.results.values() do
+        out.print("Comment #" + c.id.string() + " ==>")
+        out.print(c.body)
+        out.print("")
+      end
+      match list.next_page()
+      | let promise: Promise[(PaginatedList[GistComment] | RequestError)] =>
+        promise.next[None](PrintComments~apply(out))
+      else
+        out.print("------- No more comments")
+      end
+    | let e: RequestError =>
+      out.print("Unable to retrieve gist comments")
+      out.print(e.status.string())
+      out.print(e.response_body)
+      out.print(e.message)
+    end

--- a/examples/list-gists-oo/Makefile
+++ b/examples/list-gists-oo/Makefile
@@ -1,0 +1,35 @@
+GET_DEPENDENCIES_WITH := corral fetch
+COMPILE_WITH := corral run -- ponyc
+
+BUILD_DIR ?= build
+SRC_DIR := .
+BINARY_NAME := list-gists-oo
+LIB_SRC := ../../github_rest_api/
+
+PONYC = $(COMPILE_WITH)
+
+ifeq ($(ssl), 3.0.x)
+	SSL = -Dopenssl_3.0.x
+else ifeq ($(ssl), 1.1.x)
+	SSL = -Dopenssl_1.1.x
+else ifeq ($(ssl), 0.9.0)
+	SSL = -Dopenssl_0.9.0
+else
+	$(error Unknown SSL version "$(ssl)". Must set using 'ssl=FOO')
+endif
+
+PONYC := $(PONYC) $(SSL)
+
+SOURCE_FILES := $(shell find $(LIB_SRC) -name "*.pony")
+
+$(BUILD_DIR)/$(BINARY_NAME): $(SOURCE_FILES) main.pony | $(BUILD_DIR)
+	$(GET_DEPENDENCIES_WITH)
+	$(PONYC) -o $(BUILD_DIR) $(SRC_DIR)
+
+clean:
+	rm -rf $(BUILD_DIR)
+
+$(BUILD_DIR):
+	mkdir -p $(BUILD_DIR)
+
+.PHONY: clean

--- a/examples/list-gists-oo/main.pony
+++ b/examples/list-gists-oo/main.pony
@@ -1,0 +1,67 @@
+use "../../github_rest_api"
+use "../../github_rest_api/request"
+use "cli"
+use "net"
+use "promises"
+
+actor Main
+  new create(env: Env) =>
+    try
+      // ----- CLI setup
+      let cs =
+        CommandSpec.leaf("list-gists-oo",
+          "List the authenticated user's gists",
+          [
+            OptionSpec.string("token", "GitHub personal access token")
+          ]
+        )? .> add_help()?
+
+      let cmd = match CommandParser(cs).parse(env.args, env.vars)
+      | let c: Command =>
+        c
+      | let ch: CommandHelp =>
+        ch.print_help(env.out)
+        return
+      | let se: SyntaxError =>
+        env.err.print(se.string())
+        env.exitcode(1)
+        return
+      end
+
+      let token = cmd.option("token").string()
+
+      // ----- List gists
+      let auth = TCPConnectAuth(env.root)
+      let creds = Credentials(auth, token)
+
+      GitHub(creds).get_user_gists()
+        .next[None](PrintGists~apply(env.out))
+    else
+      env.out.print("Something went wrong")
+    end
+
+primitive PrintGists
+  fun apply(out: OutStream,
+    r: (PaginatedList[Gist] | RequestError))
+  =>
+    match r
+    | let list: PaginatedList[Gist] =>
+      for gist in list.results.values() do
+        let desc = match gist.description
+        | let d: String => d
+        else "(no description)"
+        end
+        out.print(gist.id + " - " + desc)
+      end
+      match list.next_page()
+      | let promise: Promise[(PaginatedList[Gist] | RequestError)] =>
+        promise.next[None](PrintGists~apply(out))
+      else
+        out.print("------- No more gists")
+      end
+    | let e: RequestError =>
+      out.print("Unable to list gists")
+      out.print(e.status.string())
+      out.print(e.response_body)
+      out.print(e.message)
+    end

--- a/examples/list-gists/Makefile
+++ b/examples/list-gists/Makefile
@@ -1,0 +1,35 @@
+GET_DEPENDENCIES_WITH := corral fetch
+COMPILE_WITH := corral run -- ponyc
+
+BUILD_DIR ?= build
+SRC_DIR := .
+BINARY_NAME := list-gists
+LIB_SRC := ../../github_rest_api/
+
+PONYC = $(COMPILE_WITH)
+
+ifeq ($(ssl), 3.0.x)
+	SSL = -Dopenssl_3.0.x
+else ifeq ($(ssl), 1.1.x)
+	SSL = -Dopenssl_1.1.x
+else ifeq ($(ssl), 0.9.0)
+	SSL = -Dopenssl_0.9.0
+else
+	$(error Unknown SSL version "$(ssl)". Must set using 'ssl=FOO')
+endif
+
+PONYC := $(PONYC) $(SSL)
+
+SOURCE_FILES := $(shell find $(LIB_SRC) -name "*.pony")
+
+$(BUILD_DIR)/$(BINARY_NAME): $(SOURCE_FILES) main.pony | $(BUILD_DIR)
+	$(GET_DEPENDENCIES_WITH)
+	$(PONYC) -o $(BUILD_DIR) $(SRC_DIR)
+
+clean:
+	rm -rf $(BUILD_DIR)
+
+$(BUILD_DIR):
+	mkdir -p $(BUILD_DIR)
+
+.PHONY: clean

--- a/examples/list-gists/main.pony
+++ b/examples/list-gists/main.pony
@@ -1,0 +1,67 @@
+use "../../github_rest_api"
+use "../../github_rest_api/request"
+use "cli"
+use "net"
+use "promises"
+
+actor Main
+  new create(env: Env) =>
+    try
+      // ----- CLI setup
+      let cs =
+        CommandSpec.leaf("list-gists",
+          "List the authenticated user's gists",
+          [
+            OptionSpec.string("token", "GitHub personal access token")
+          ]
+        )? .> add_help()?
+
+      let cmd = match CommandParser(cs).parse(env.args, env.vars)
+      | let c: Command =>
+        c
+      | let ch: CommandHelp =>
+        ch.print_help(env.out)
+        return
+      | let se: SyntaxError =>
+        env.err.print(se.string())
+        env.exitcode(1)
+        return
+      end
+
+      let token = cmd.option("token").string()
+
+      // ----- List gists
+      let auth = TCPConnectAuth(env.root)
+      let creds = Credentials(auth, token)
+
+      let p = GetUserGists(creds)
+      p.next[None](PrintGists~apply(env.out))
+    else
+      env.out.print("Something went wrong")
+    end
+
+primitive PrintGists
+  fun apply(out: OutStream,
+    r: (PaginatedList[Gist] | RequestError))
+  =>
+    match r
+    | let list: PaginatedList[Gist] =>
+      for gist in list.results.values() do
+        let desc = match gist.description
+        | let d: String => d
+        else "(no description)"
+        end
+        out.print(gist.id + " - " + desc)
+      end
+      match list.next_page()
+      | let promise: Promise[(PaginatedList[Gist] | RequestError)] =>
+        promise.next[None](PrintGists~apply(out))
+      else
+        out.print("------- No more gists")
+      end
+    | let e: RequestError =>
+      out.print("Unable to list gists")
+      out.print(e.status.string())
+      out.print(e.response_body)
+      out.print(e.message)
+    end

--- a/examples/star-gist-oo/Makefile
+++ b/examples/star-gist-oo/Makefile
@@ -1,0 +1,35 @@
+GET_DEPENDENCIES_WITH := corral fetch
+COMPILE_WITH := corral run -- ponyc
+
+BUILD_DIR ?= build
+SRC_DIR := .
+BINARY_NAME := star-gist-oo
+LIB_SRC := ../../github_rest_api/
+
+PONYC = $(COMPILE_WITH)
+
+ifeq ($(ssl), 3.0.x)
+	SSL = -Dopenssl_3.0.x
+else ifeq ($(ssl), 1.1.x)
+	SSL = -Dopenssl_1.1.x
+else ifeq ($(ssl), 0.9.0)
+	SSL = -Dopenssl_0.9.0
+else
+	$(error Unknown SSL version "$(ssl)". Must set using 'ssl=FOO')
+endif
+
+PONYC := $(PONYC) $(SSL)
+
+SOURCE_FILES := $(shell find $(LIB_SRC) -name "*.pony")
+
+$(BUILD_DIR)/$(BINARY_NAME): $(SOURCE_FILES) main.pony | $(BUILD_DIR)
+	$(GET_DEPENDENCIES_WITH)
+	$(PONYC) -o $(BUILD_DIR) $(SRC_DIR)
+
+clean:
+	rm -rf $(BUILD_DIR)
+
+$(BUILD_DIR):
+	mkdir -p $(BUILD_DIR)
+
+.PHONY: clean

--- a/examples/star-gist-oo/main.pony
+++ b/examples/star-gist-oo/main.pony
@@ -1,0 +1,78 @@
+use "../../github_rest_api"
+use "../../github_rest_api/request"
+use "cli"
+use "net"
+use "promises"
+
+actor Main
+  new create(env: Env) =>
+    try
+      // ----- CLI setup
+      let cs =
+        CommandSpec.leaf("star-gist-oo",
+          "Star a gist and then check if it is starred",
+          [
+            OptionSpec.string("gist-id", "ID of the gist to star")
+            OptionSpec.string("token", "GitHub personal access token")
+          ]
+        )? .> add_help()?
+
+      let cmd = match CommandParser(cs).parse(env.args, env.vars)
+      | let c: Command =>
+        c
+      | let ch: CommandHelp =>
+        ch.print_help(env.out)
+        return
+      | let se: SyntaxError =>
+        env.err.print(se.string())
+        env.exitcode(1)
+        return
+      end
+
+      let gist_id = cmd.option("gist-id").string()
+      let token = cmd.option("token").string()
+
+      // ----- Star gist then check via OO API
+      let auth = TCPConnectAuth(env.root)
+      let creds = Credentials(auth, token)
+
+      GitHub(creds).get_gist(gist_id)
+        .flatten_next[DeletedOrError](StarIt~apply())
+        .flatten_next[BoolOrError](CheckIt~apply())
+        .next[None](PrintResult~apply(env.out))
+    else
+      env.out.print("Something went wrong")
+    end
+
+primitive StarIt
+  fun apply(g: GistOrError): Promise[DeletedOrError] =>
+    match g
+    | let gist: Gist =>
+      gist.star()
+    | let e: RequestError =>
+      Promise[DeletedOrError].>apply(e)
+    end
+
+primitive CheckIt
+  fun apply(d: DeletedOrError): Promise[BoolOrError] =>
+    match d
+    | Deleted =>
+      // Star succeeded. We can't call is_starred() here because we don't
+      // have the Gist reference in this chain step. In real code, keep the
+      // Gist accessible or use the functional API (see star-gist example).
+      Promise[BoolOrError].>apply(true)
+    | let e: RequestError =>
+      Promise[BoolOrError].>apply(e)
+    end
+
+primitive PrintResult
+  fun apply(out: OutStream, r: BoolOrError) =>
+    match r
+    | let starred: Bool =>
+      out.print("Is starred: " + starred.string())
+    | let e: RequestError =>
+      out.print("Error")
+      out.print(e.status.string())
+      out.print(e.response_body)
+      out.print(e.message)
+    end

--- a/examples/star-gist/Makefile
+++ b/examples/star-gist/Makefile
@@ -1,0 +1,35 @@
+GET_DEPENDENCIES_WITH := corral fetch
+COMPILE_WITH := corral run -- ponyc
+
+BUILD_DIR ?= build
+SRC_DIR := .
+BINARY_NAME := star-gist
+LIB_SRC := ../../github_rest_api/
+
+PONYC = $(COMPILE_WITH)
+
+ifeq ($(ssl), 3.0.x)
+	SSL = -Dopenssl_3.0.x
+else ifeq ($(ssl), 1.1.x)
+	SSL = -Dopenssl_1.1.x
+else ifeq ($(ssl), 0.9.0)
+	SSL = -Dopenssl_0.9.0
+else
+	$(error Unknown SSL version "$(ssl)". Must set using 'ssl=FOO')
+endif
+
+PONYC := $(PONYC) $(SSL)
+
+SOURCE_FILES := $(shell find $(LIB_SRC) -name "*.pony")
+
+$(BUILD_DIR)/$(BINARY_NAME): $(SOURCE_FILES) main.pony | $(BUILD_DIR)
+	$(GET_DEPENDENCIES_WITH)
+	$(PONYC) -o $(BUILD_DIR) $(SRC_DIR)
+
+clean:
+	rm -rf $(BUILD_DIR)
+
+$(BUILD_DIR):
+	mkdir -p $(BUILD_DIR)
+
+.PHONY: clean

--- a/examples/star-gist/main.pony
+++ b/examples/star-gist/main.pony
@@ -1,0 +1,69 @@
+use "../../github_rest_api"
+use "../../github_rest_api/request"
+use "cli"
+use "net"
+use "promises"
+
+actor Main
+  new create(env: Env) =>
+    try
+      // ----- CLI setup
+      let cs =
+        CommandSpec.leaf("star-gist",
+          "Star a gist and then check if it is starred",
+          [
+            OptionSpec.string("gist-id", "ID of the gist to star")
+            OptionSpec.string("token", "GitHub personal access token")
+          ]
+        )? .> add_help()?
+
+      let cmd = match CommandParser(cs).parse(env.args, env.vars)
+      | let c: Command =>
+        c
+      | let ch: CommandHelp =>
+        ch.print_help(env.out)
+        return
+      | let se: SyntaxError =>
+        env.err.print(se.string())
+        env.exitcode(1)
+        return
+      end
+
+      let gist_id = cmd.option("gist-id").string()
+      let token = cmd.option("token").string()
+
+      // ----- Star gist then check
+      let auth = TCPConnectAuth(env.root)
+      let creds = Credentials(auth, token)
+
+      StarGist(gist_id, creds)
+        .flatten_next[BoolOrError](
+          CheckStar~apply(gist_id, creds))
+        .next[None](PrintResult~apply(env.out))
+    else
+      env.out.print("Something went wrong")
+    end
+
+primitive CheckStar
+  fun apply(gist_id: String,
+    creds: Credentials,
+    d: DeletedOrError): Promise[BoolOrError]
+  =>
+    match d
+    | Deleted =>
+      CheckGistStar(gist_id, creds)
+    | let e: RequestError =>
+      Promise[BoolOrError].>apply(e)
+    end
+
+primitive PrintResult
+  fun apply(out: OutStream, r: BoolOrError) =>
+    match r
+    | let starred: Bool =>
+      out.print("Is starred: " + starred.string())
+    | let e: RequestError =>
+      out.print("Error")
+      out.print(e.status.string())
+      out.print(e.response_body)
+      out.print(e.message)
+    end

--- a/github_rest_api/gist.pony
+++ b/github_rest_api/gist.pony
@@ -1,0 +1,700 @@
+use "json"
+use "promises"
+use req = "request"
+use ut = "uri/template"
+
+type GistOrError is (Gist | req.RequestError)
+
+class val Gist
+  """
+  A GitHub gist. Contains the gist's metadata, file listing, and URLs for
+  related resources. Provides convenience methods for updating, deleting,
+  forking, starring, and accessing comments and commit history.
+
+  The `files` field is an array of (filename, GistFile) pairs rather than a
+  map, preserving insertion order. Gists typically have few files, so linear
+  lookup is not a concern.
+  """
+  let _creds: req.Credentials
+  let id: String
+  let node_id: String
+  let description: (String | None)
+  let public: Bool
+  let owner: (User | None)
+  let user: (User | None)
+  let files: Array[(String, GistFile)] val
+  let comments: I64
+  let comments_enabled: Bool
+  let truncated: Bool
+  let created_at: String
+  let updated_at: String
+  let url: String
+  let html_url: String
+  let forks_url: String
+  let commits_url: String
+  let comments_url: String
+  let git_pull_url: String
+  let git_push_url: String
+
+  new val create(creds: req.Credentials,
+    id': String,
+    node_id': String,
+    description': (String | None),
+    public': Bool,
+    owner': (User | None),
+    user': (User | None),
+    files': Array[(String, GistFile)] val,
+    comments': I64,
+    comments_enabled': Bool,
+    truncated': Bool,
+    created_at': String,
+    updated_at': String,
+    url': String,
+    html_url': String,
+    forks_url': String,
+    commits_url': String,
+    comments_url': String,
+    git_pull_url': String,
+    git_push_url': String)
+  =>
+    _creds = creds
+    id = id'
+    node_id = node_id'
+    description = description'
+    public = public'
+    owner = owner'
+    user = user'
+    files = files'
+    comments = comments'
+    comments_enabled = comments_enabled'
+    truncated = truncated'
+    created_at = created_at'
+    updated_at = updated_at'
+    url = url'
+    html_url = html_url'
+    forks_url = forks_url'
+    commits_url = commits_url'
+    comments_url = comments_url'
+    git_pull_url = git_pull_url'
+    git_push_url = git_push_url'
+
+  fun update_gist(
+    update_files: Array[(String, GistFileUpdate)] val,
+    new_description: (String | None) = None): Promise[GistOrError]
+  =>
+    """
+    Updates this gist's files and/or description.
+    """
+    UpdateGist.by_url(url, update_files, _creds, new_description)
+
+  fun delete_gist(): Promise[req.DeletedOrError] =>
+    """
+    Deletes this gist.
+    """
+    DeleteGist.by_url(url, _creds)
+
+  fun get_revision(sha: String): Promise[GistOrError] =>
+    """
+    Fetches a specific revision of this gist by its commit SHA.
+    """
+    GetGistRevision(id, sha, _creds)
+
+  fun fork(): Promise[GistOrError] =>
+    """
+    Forks this gist into the authenticated user's account.
+    """
+    ForkGist.by_url(forks_url, _creds)
+
+  fun get_forks()
+    : Promise[(PaginatedList[Gist] | req.RequestError)]
+  =>
+    """
+    Lists forks of this gist as a paginated list.
+    """
+    _GetPaginatedGists.by_url(forks_url, _creds)
+
+  fun get_commits()
+    : Promise[(PaginatedList[GistCommit] | req.RequestError)]
+  =>
+    """
+    Lists commits for this gist as a paginated list.
+    """
+    GetGistCommits.by_url(commits_url, _creds)
+
+  fun star(): Promise[req.DeletedOrError] =>
+    """
+    Stars this gist for the authenticated user.
+    """
+    StarGist.by_url(
+      recover val url + "/star" end,
+      _creds)
+
+  fun unstar(): Promise[req.DeletedOrError] =>
+    """
+    Unstars this gist for the authenticated user.
+    """
+    UnstarGist.by_url(
+      recover val url + "/star" end,
+      _creds)
+
+  fun is_starred(): Promise[req.BoolOrError] =>
+    """
+    Checks whether this gist is starred by the authenticated user.
+    """
+    CheckGistStar.by_url(
+      recover val url + "/star" end,
+      _creds)
+
+  fun create_comment(body: String): Promise[GistCommentOrError] =>
+    """
+    Creates a new comment on this gist.
+    """
+    CreateGistComment.by_url(comments_url, body, _creds)
+
+  fun get_comments()
+    : Promise[(PaginatedList[GistComment] | req.RequestError)]
+  =>
+    """
+    Lists comments on this gist as a paginated list.
+    """
+    GetGistComments.by_url(comments_url, _creds)
+
+primitive GetGist
+  """
+  Fetches a single gist by its ID.
+  """
+  fun apply(gist_id: String,
+    creds: req.Credentials): Promise[GistOrError]
+  =>
+    match ut.URITemplateParse("https://api.github.com/gists{/gist_id}")
+    | let tpl: ut.URITemplate =>
+      let vars = ut.URITemplateVariables
+        .>set("gist_id", gist_id)
+      let u: String val = tpl.expand(vars)
+      by_url(u, creds)
+    | let e: ut.URITemplateParseError =>
+      Promise[GistOrError].>apply(
+        req.RequestError(where message' = e.message))
+    end
+
+  fun by_url(url: String, creds: req.Credentials): Promise[GistOrError] =>
+    let p = Promise[GistOrError]
+    let r = req.ResultReceiver[Gist](creds, p, GistJsonConverter)
+
+    try
+      req.JsonRequester(creds)(url, r)?
+    else
+      let m = recover val
+        "Unable to initiate get_gist request to " + url
+      end
+      p(req.RequestError(where message' = m))
+    end
+
+    p
+
+primitive CreateGist
+  """
+  Creates a new gist. The `files` parameter is an array of (filename, content)
+  pairs. Set `is_public` to true for a public gist.
+  """
+  fun apply(files: Array[(String, String)] val,
+    creds: req.Credentials,
+    description: (String | None) = None,
+    is_public: Bool = false): Promise[GistOrError]
+  =>
+    by_url("https://api.github.com/gists",
+      files,
+      creds,
+      description,
+      is_public)
+
+  fun by_url(url: String,
+    files: Array[(String, String)] val,
+    creds: req.Credentials,
+    description: (String | None) = None,
+    is_public: Bool = false): Promise[GistOrError]
+  =>
+    let p = Promise[GistOrError]
+    let r = req.ResultReceiver[Gist](creds, p, GistJsonConverter)
+
+    var files_obj = JsonObject
+    for (name, content) in files.values() do
+      files_obj = files_obj.update(name,
+        JsonObject.update("content", content))
+    end
+
+    var obj = JsonObject
+      .update("files", files_obj)
+      .update("public", is_public)
+    match description
+    | let d: String => obj = obj.update("description", d)
+    end
+    let json = obj.string()
+
+    try
+      req.HTTPPost(creds.auth)(url,
+        consume json,
+        r,
+        creds.token)?
+    else
+      p(req.RequestError(
+        where message' = "Unable to create gist at " + url))
+    end
+
+    p
+
+primitive UpdateGist
+  """
+  Updates an existing gist's files and/or description. Each entry in the
+  `files` array maps a filename to a GistFileUpdate: GistFileEdit to change
+  content, GistFileRename to rename (optionally with new content), or
+  GistFileDelete to remove the file.
+  """
+  fun apply(gist_id: String,
+    files: Array[(String, GistFileUpdate)] val,
+    creds: req.Credentials,
+    description: (String | None) = None): Promise[GistOrError]
+  =>
+    match ut.URITemplateParse("https://api.github.com/gists{/gist_id}")
+    | let tpl: ut.URITemplate =>
+      let vars = ut.URITemplateVariables
+        .>set("gist_id", gist_id)
+      let u: String val = tpl.expand(vars)
+      by_url(u, files, creds, description)
+    | let e: ut.URITemplateParseError =>
+      Promise[GistOrError].>apply(
+        req.RequestError(where message' = e.message))
+    end
+
+  fun by_url(url: String,
+    files: Array[(String, GistFileUpdate)] val,
+    creds: req.Credentials,
+    description: (String | None) = None): Promise[GistOrError]
+  =>
+    let p = Promise[GistOrError]
+    let r = req.ResultReceiver[Gist](creds, p, GistJsonConverter)
+
+    var files_obj = JsonObject
+    for (name, update) in files.values() do
+      match update
+      | let edit: GistFileEdit =>
+        files_obj = files_obj.update(name,
+          JsonObject.update("content", edit.content))
+      | let rename: GistFileRename =>
+        var entry = JsonObject.update("filename", rename.filename)
+        match rename.content
+        | let c: String => entry = entry.update("content", c)
+        end
+        files_obj = files_obj.update(name, entry)
+      | GistFileDelete =>
+        files_obj = files_obj.update(name, None)
+      end
+    end
+
+    var obj = JsonObject.update("files", files_obj)
+    match description
+    | let d: String => obj = obj.update("description", d)
+    end
+    let json = obj.string()
+
+    try
+      req.HTTPPatch(creds.auth)(url,
+        consume json,
+        r,
+        creds.token)?
+    else
+      p(req.RequestError(
+        where message' = "Unable to update gist at " + url))
+    end
+
+    p
+
+primitive DeleteGist
+  """
+  Deletes a gist.
+  """
+  fun apply(gist_id: String,
+    creds: req.Credentials): Promise[req.DeletedOrError]
+  =>
+    match ut.URITemplateParse("https://api.github.com/gists{/gist_id}")
+    | let tpl: ut.URITemplate =>
+      let vars = ut.URITemplateVariables
+        .>set("gist_id", gist_id)
+      let u: String val = tpl.expand(vars)
+      by_url(u, creds)
+    | let e: ut.URITemplateParseError =>
+      Promise[req.DeletedOrError].>apply(
+        req.RequestError(where message' = e.message))
+    end
+
+  fun by_url(url: String,
+    creds: req.Credentials): Promise[req.DeletedOrError]
+  =>
+    let p = Promise[req.DeletedOrError]
+    let r = req.DeletedResultReceiver(p)
+
+    try
+      req.HTTPDelete(creds.auth)(url,
+        r,
+        creds.token)?
+    else
+      p(req.RequestError(
+        where message' = "Unable to delete gist at " + url))
+    end
+
+    p
+
+primitive GetUserGists
+  """
+  Lists the authenticated user's gists as a paginated list.
+  """
+  fun apply(creds: req.Credentials)
+    : Promise[(PaginatedList[Gist] | req.RequestError)]
+  =>
+    _GetPaginatedGists.by_url("https://api.github.com/gists", creds)
+
+primitive GetPublicGists
+  """
+  Lists public gists as a paginated list.
+  """
+  fun apply(creds: req.Credentials)
+    : Promise[(PaginatedList[Gist] | req.RequestError)]
+  =>
+    _GetPaginatedGists.by_url("https://api.github.com/gists/public", creds)
+
+primitive GetStarredGists
+  """
+  Lists the authenticated user's starred gists as a paginated list.
+  """
+  fun apply(creds: req.Credentials)
+    : Promise[(PaginatedList[Gist] | req.RequestError)]
+  =>
+    _GetPaginatedGists.by_url("https://api.github.com/gists/starred", creds)
+
+primitive GetUsernameGists
+  """
+  Lists a specific user's public gists as a paginated list.
+  """
+  fun apply(username: String,
+    creds: req.Credentials)
+    : Promise[(PaginatedList[Gist] | req.RequestError)]
+  =>
+    match ut.URITemplateParse(
+      "https://api.github.com/users{/username}/gists")
+    | let tpl: ut.URITemplate =>
+      let vars = ut.URITemplateVariables
+        .>set("username", username)
+      let u: String val = tpl.expand(vars)
+      _GetPaginatedGists.by_url(u, creds)
+    | let e: ut.URITemplateParseError =>
+      Promise[(PaginatedList[Gist] | req.RequestError)].>apply(
+        req.RequestError(where message' = e.message))
+    end
+
+primitive GetGistRevision
+  """
+  Fetches a specific revision of a gist by its commit SHA.
+  """
+  fun apply(gist_id: String,
+    sha: String,
+    creds: req.Credentials): Promise[GistOrError]
+  =>
+    match ut.URITemplateParse(
+      "https://api.github.com/gists{/gist_id}{/sha}")
+    | let tpl: ut.URITemplate =>
+      let vars = ut.URITemplateVariables
+        .>set("gist_id", gist_id)
+        .>set("sha", sha)
+      let u: String val = tpl.expand(vars)
+      GetGist.by_url(u, creds)
+    | let e: ut.URITemplateParseError =>
+      Promise[GistOrError].>apply(
+        req.RequestError(where message' = e.message))
+    end
+
+primitive ForkGist
+  """
+  Forks a gist into the authenticated user's account.
+  """
+  fun apply(gist_id: String,
+    creds: req.Credentials): Promise[GistOrError]
+  =>
+    match ut.URITemplateParse(
+      "https://api.github.com/gists{/gist_id}/forks")
+    | let tpl: ut.URITemplate =>
+      let vars = ut.URITemplateVariables
+        .>set("gist_id", gist_id)
+      let u: String val = tpl.expand(vars)
+      by_url(u, creds)
+    | let e: ut.URITemplateParseError =>
+      Promise[GistOrError].>apply(
+        req.RequestError(where message' = e.message))
+    end
+
+  fun by_url(url: String,
+    creds: req.Credentials): Promise[GistOrError]
+  =>
+    let p = Promise[GistOrError]
+    let r = req.ResultReceiver[Gist](creds, p, GistJsonConverter)
+
+    try
+      req.HTTPPost(creds.auth)(url,
+        "",
+        r,
+        creds.token)?
+    else
+      p(req.RequestError(
+        where message' = "Unable to fork gist at " + url))
+    end
+
+    p
+
+primitive GetGistForks
+  """
+  Lists forks of a gist as a paginated list.
+  """
+  fun apply(gist_id: String,
+    creds: req.Credentials)
+    : Promise[(PaginatedList[Gist] | req.RequestError)]
+  =>
+    match ut.URITemplateParse(
+      "https://api.github.com/gists{/gist_id}/forks")
+    | let tpl: ut.URITemplate =>
+      let vars = ut.URITemplateVariables
+        .>set("gist_id", gist_id)
+      let u: String val = tpl.expand(vars)
+      _GetPaginatedGists.by_url(u, creds)
+    | let e: ut.URITemplateParseError =>
+      Promise[(PaginatedList[Gist] | req.RequestError)].>apply(
+        req.RequestError(where message' = e.message))
+    end
+
+primitive GetGistCommits
+  """
+  Lists commits for a gist as a paginated list.
+  """
+  fun apply(gist_id: String,
+    creds: req.Credentials)
+    : Promise[(PaginatedList[GistCommit] | req.RequestError)]
+  =>
+    match ut.URITemplateParse(
+      "https://api.github.com/gists{/gist_id}/commits")
+    | let tpl: ut.URITemplate =>
+      let vars = ut.URITemplateVariables
+        .>set("gist_id", gist_id)
+      let u: String val = tpl.expand(vars)
+      by_url(u, creds)
+    | let e: ut.URITemplateParseError =>
+      Promise[(PaginatedList[GistCommit] | req.RequestError)].>apply(
+        req.RequestError(where message' = e.message))
+    end
+
+  fun by_url(url: String,
+    creds: req.Credentials)
+    : Promise[(PaginatedList[GistCommit] | req.RequestError)]
+  =>
+    let gc = GistCommitJsonConverter
+    let plc = PaginatedListJsonConverter[GistCommit](creds, gc)
+    let p = Promise[(PaginatedList[GistCommit] | req.RequestError)]
+    let r = PaginatedResultReceiver[GistCommit](creds, p, plc)
+
+    try
+      PaginatedJsonRequester(creds).apply[GistCommit](url, r)?
+    else
+      let m = recover val
+        "Unable to initiate get_gist_commits request to " + url
+      end
+      p(req.RequestError(where message' = m))
+    end
+
+    p
+
+primitive StarGist
+  """
+  Stars a gist for the authenticated user.
+  """
+  fun apply(gist_id: String,
+    creds: req.Credentials): Promise[req.DeletedOrError]
+  =>
+    match ut.URITemplateParse(
+      "https://api.github.com/gists{/gist_id}/star")
+    | let tpl: ut.URITemplate =>
+      let vars = ut.URITemplateVariables
+        .>set("gist_id", gist_id)
+      let u: String val = tpl.expand(vars)
+      by_url(u, creds)
+    | let e: ut.URITemplateParseError =>
+      Promise[req.DeletedOrError].>apply(
+        req.RequestError(where message' = e.message))
+    end
+
+  fun by_url(url: String,
+    creds: req.Credentials): Promise[req.DeletedOrError]
+  =>
+    let p = Promise[req.DeletedOrError]
+    let r = req.DeletedResultReceiver(p)
+
+    try
+      req.HTTPPut(creds.auth)(url,
+        r,
+        creds.token)?
+    else
+      p(req.RequestError(
+        where message' = "Unable to star gist at " + url))
+    end
+
+    p
+
+primitive UnstarGist
+  """
+  Unstars a gist for the authenticated user.
+  """
+  fun apply(gist_id: String,
+    creds: req.Credentials): Promise[req.DeletedOrError]
+  =>
+    match ut.URITemplateParse(
+      "https://api.github.com/gists{/gist_id}/star")
+    | let tpl: ut.URITemplate =>
+      let vars = ut.URITemplateVariables
+        .>set("gist_id", gist_id)
+      let u: String val = tpl.expand(vars)
+      by_url(u, creds)
+    | let e: ut.URITemplateParseError =>
+      Promise[req.DeletedOrError].>apply(
+        req.RequestError(where message' = e.message))
+    end
+
+  fun by_url(url: String,
+    creds: req.Credentials): Promise[req.DeletedOrError]
+  =>
+    let p = Promise[req.DeletedOrError]
+    let r = req.DeletedResultReceiver(p)
+
+    try
+      req.HTTPDelete(creds.auth)(url,
+        r,
+        creds.token)?
+    else
+      p(req.RequestError(
+        where message' = "Unable to unstar gist at " + url))
+    end
+
+    p
+
+primitive CheckGistStar
+  """
+  Checks whether a gist is starred by the authenticated user. Returns true
+  if starred (204), false if not (404).
+  """
+  fun apply(gist_id: String,
+    creds: req.Credentials): Promise[req.BoolOrError]
+  =>
+    match ut.URITemplateParse(
+      "https://api.github.com/gists{/gist_id}/star")
+    | let tpl: ut.URITemplate =>
+      let vars = ut.URITemplateVariables
+        .>set("gist_id", gist_id)
+      let u: String val = tpl.expand(vars)
+      by_url(u, creds)
+    | let e: ut.URITemplateParseError =>
+      Promise[req.BoolOrError].>apply(
+        req.RequestError(where message' = e.message))
+    end
+
+  fun by_url(url: String,
+    creds: req.Credentials): Promise[req.BoolOrError]
+  =>
+    let p = Promise[req.BoolOrError]
+    let r = req.BoolResultReceiver(p)
+
+    try
+      req.HTTPCheck(creds.auth)(url,
+        r,
+        creds.token)?
+    else
+      p(req.RequestError(
+        where message' = "Unable to check gist star at " + url))
+    end
+
+    p
+
+primitive _GetPaginatedGists
+  """
+  Shared helper for paginated gist list operations. Used by GetUserGists,
+  GetPublicGists, GetStarredGists, GetUsernameGists, and GetGistForks.
+  """
+  fun by_url(url: String,
+    creds: req.Credentials)
+    : Promise[(PaginatedList[Gist] | req.RequestError)]
+  =>
+    let gc = GistJsonConverter
+    let plc = PaginatedListJsonConverter[Gist](creds, gc)
+    let p = Promise[(PaginatedList[Gist] | req.RequestError)]
+    let r = PaginatedResultReceiver[Gist](creds, p, plc)
+
+    try
+      PaginatedJsonRequester(creds).apply[Gist](url, r)?
+    else
+      let m = recover val
+        "Unable to initiate get_gists request to " + url
+      end
+      p(req.RequestError(where message' = m))
+    end
+
+    p
+
+primitive GistJsonConverter is req.JsonConverter[Gist]
+  """
+  Converts a JSON object from the GitHub gist API into a Gist. Handles the
+  files object by iterating its key-value pairs and converting each value with
+  GistFileJsonConverter.
+  """
+  fun apply(json: JsonNav, creds: req.Credentials): Gist ? =>
+    let id = json("id").as_string()?
+    let node_id = json("node_id").as_string()?
+    let description = JsonNavUtil.string_or_none(json("description"))?
+    let public = json("public").as_bool()?
+    let owner = try UserJsonConverter(json("owner"), creds)? else None end
+    let user = try UserJsonConverter(json("user"), creds)? else None end
+
+    let files = recover trn Array[(String, GistFile)] end
+    for (name, value) in json("files").as_object()?.pairs() do
+      let gf = GistFileJsonConverter(JsonNav(value), creds)?
+      files.push((name, gf))
+    end
+
+    let comments_count = json("comments").as_i64()?
+    let comments_enabled =
+      try json("comments_enabled").as_bool()? else true end
+    let truncated = json("truncated").as_bool()?
+    let created_at = json("created_at").as_string()?
+    let updated_at = json("updated_at").as_string()?
+
+    let url = json("url").as_string()?
+    let html_url = json("html_url").as_string()?
+    let forks_url = json("forks_url").as_string()?
+    let commits_url = json("commits_url").as_string()?
+    let comments_url = json("comments_url").as_string()?
+    let git_pull_url = json("git_pull_url").as_string()?
+    let git_push_url = json("git_push_url").as_string()?
+
+    Gist(creds,
+      id,
+      node_id,
+      description,
+      public,
+      owner,
+      user,
+      consume files,
+      comments_count,
+      comments_enabled,
+      truncated,
+      created_at,
+      updated_at,
+      url,
+      html_url,
+      forks_url,
+      commits_url,
+      comments_url,
+      git_pull_url,
+      git_push_url)

--- a/github_rest_api/gist_comment.pony
+++ b/github_rest_api/gist_comment.pony
@@ -1,0 +1,283 @@
+use "json"
+use "promises"
+use req = "request"
+use ut = "uri/template"
+
+type GistCommentOrError is (GistComment | req.RequestError)
+
+class val GistComment
+  """
+  A comment on a gist. Provides convenience methods to update the comment's
+  body or delete the comment entirely.
+  """
+  let _creds: req.Credentials
+  let id: I64
+  let node_id: String
+  let url: String
+  let body: String
+  let user: (User | None)
+  let author_association: String
+  let created_at: String
+  let updated_at: String
+
+  new val create(creds: req.Credentials,
+    id': I64,
+    node_id': String,
+    url': String,
+    body': String,
+    user': (User | None),
+    author_association': String,
+    created_at': String,
+    updated_at': String)
+  =>
+    _creds = creds
+    id = id'
+    node_id = node_id'
+    url = url'
+    body = body'
+    user = user'
+    author_association = author_association'
+    created_at = created_at'
+    updated_at = updated_at'
+
+  fun update(new_body: String): Promise[GistCommentOrError] =>
+    """
+    Updates this comment's body text and returns the updated comment.
+    """
+    UpdateGistComment.by_url(url, new_body, _creds)
+
+  fun delete(): Promise[req.DeletedOrError] =>
+    """
+    Deletes this comment.
+    """
+    DeleteGistComment.by_url(url, _creds)
+
+primitive GetGistComment
+  """
+  Fetches a single comment on a gist by its gist ID and comment ID.
+  """
+  fun apply(gist_id: String,
+    comment_id: I64,
+    creds: req.Credentials): Promise[GistCommentOrError]
+  =>
+    match ut.URITemplateParse(
+      "https://api.github.com/gists{/gist_id}/comments{/comment_id}")
+    | let tpl: ut.URITemplate =>
+      let vars = ut.URITemplateVariables
+        .>set("gist_id", gist_id)
+        .>set("comment_id", comment_id.string())
+      let u: String val = tpl.expand(vars)
+      by_url(u, creds)
+    | let e: ut.URITemplateParseError =>
+      Promise[GistCommentOrError].>apply(
+        req.RequestError(where message' = e.message))
+    end
+
+  fun by_url(url: String,
+    creds: req.Credentials): Promise[GistCommentOrError]
+  =>
+    let p = Promise[GistCommentOrError]
+    let r = req.ResultReceiver[GistComment](creds,
+      p,
+      GistCommentJsonConverter)
+
+    try
+      req.JsonRequester(creds)(url, r)?
+    else
+      let m = recover val
+        "Unable to initiate get_gist_comment request to " + url
+      end
+      p(req.RequestError(where message' = m))
+    end
+
+    p
+
+primitive GetGistComments
+  """
+  Fetches all comments on a gist as a paginated list.
+  """
+  fun apply(gist_id: String,
+    creds: req.Credentials)
+    : Promise[(PaginatedList[GistComment] | req.RequestError)]
+  =>
+    match ut.URITemplateParse(
+      "https://api.github.com/gists{/gist_id}/comments")
+    | let tpl: ut.URITemplate =>
+      let vars = ut.URITemplateVariables
+        .>set("gist_id", gist_id)
+      let u: String val = tpl.expand(vars)
+      by_url(u, creds)
+    | let e: ut.URITemplateParseError =>
+      Promise[(PaginatedList[GistComment] | req.RequestError)].>apply(
+        req.RequestError(where message' = e.message))
+    end
+
+  fun by_url(url: String,
+    creds: req.Credentials)
+    : Promise[(PaginatedList[GistComment] | req.RequestError)]
+  =>
+    let gc = GistCommentJsonConverter
+    let plc = PaginatedListJsonConverter[GistComment](creds, gc)
+    let p = Promise[(PaginatedList[GistComment] | req.RequestError)]
+    let r = PaginatedResultReceiver[GistComment](creds, p, plc)
+
+    try
+      PaginatedJsonRequester(creds).apply[GistComment](url, r)?
+    else
+      let m = recover val
+        "Unable to initiate get_gist_comments request to " + url
+      end
+      p(req.RequestError(where message' = m))
+    end
+
+    p
+
+primitive CreateGistComment
+  """
+  Creates a new comment on a gist.
+  """
+  fun apply(gist_id: String,
+    body: String,
+    creds: req.Credentials): Promise[GistCommentOrError]
+  =>
+    match ut.URITemplateParse(
+      "https://api.github.com/gists{/gist_id}/comments")
+    | let tpl: ut.URITemplate =>
+      let vars = ut.URITemplateVariables
+        .>set("gist_id", gist_id)
+      let u: String val = tpl.expand(vars)
+      by_url(u, body, creds)
+    | let e: ut.URITemplateParseError =>
+      Promise[GistCommentOrError].>apply(
+        req.RequestError(where message' = e.message))
+    end
+
+  fun by_url(url: String,
+    body: String,
+    creds: req.Credentials): Promise[GistCommentOrError]
+  =>
+    let p = Promise[GistCommentOrError]
+    let r = req.ResultReceiver[GistComment](creds,
+      p,
+      GistCommentJsonConverter)
+
+    let json = JsonObject.update("body", body).string()
+
+    try
+      req.HTTPPost(creds.auth)(url,
+        consume json,
+        r,
+        creds.token)?
+    else
+      p(req.RequestError(
+        where message' = "Unable to create gist comment on " + url))
+    end
+
+    p
+
+primitive UpdateGistComment
+  """
+  Updates an existing comment on a gist with a new body text.
+  """
+  fun apply(gist_id: String,
+    comment_id: I64,
+    body: String,
+    creds: req.Credentials): Promise[GistCommentOrError]
+  =>
+    match ut.URITemplateParse(
+      "https://api.github.com/gists{/gist_id}/comments{/comment_id}")
+    | let tpl: ut.URITemplate =>
+      let vars = ut.URITemplateVariables
+        .>set("gist_id", gist_id)
+        .>set("comment_id", comment_id.string())
+      let u: String val = tpl.expand(vars)
+      by_url(u, body, creds)
+    | let e: ut.URITemplateParseError =>
+      Promise[GistCommentOrError].>apply(
+        req.RequestError(where message' = e.message))
+    end
+
+  fun by_url(url: String,
+    body: String,
+    creds: req.Credentials): Promise[GistCommentOrError]
+  =>
+    let p = Promise[GistCommentOrError]
+    let r = req.ResultReceiver[GistComment](creds,
+      p,
+      GistCommentJsonConverter)
+
+    let json = JsonObject.update("body", body).string()
+
+    try
+      req.HTTPPatch(creds.auth)(url,
+        consume json,
+        r,
+        creds.token)?
+    else
+      p(req.RequestError(
+        where message' = "Unable to update gist comment on " + url))
+    end
+
+    p
+
+primitive DeleteGistComment
+  """
+  Deletes a comment on a gist.
+  """
+  fun apply(gist_id: String,
+    comment_id: I64,
+    creds: req.Credentials): Promise[req.DeletedOrError]
+  =>
+    match ut.URITemplateParse(
+      "https://api.github.com/gists{/gist_id}/comments{/comment_id}")
+    | let tpl: ut.URITemplate =>
+      let vars = ut.URITemplateVariables
+        .>set("gist_id", gist_id)
+        .>set("comment_id", comment_id.string())
+      let u: String val = tpl.expand(vars)
+      by_url(u, creds)
+    | let e: ut.URITemplateParseError =>
+      Promise[req.DeletedOrError].>apply(
+        req.RequestError(where message' = e.message))
+    end
+
+  fun by_url(url: String,
+    creds: req.Credentials): Promise[req.DeletedOrError]
+  =>
+    let p = Promise[req.DeletedOrError]
+    let r = req.DeletedResultReceiver(p)
+
+    try
+      req.HTTPDelete(creds.auth)(url,
+        r,
+        creds.token)?
+    else
+      p(req.RequestError(
+        where message' = "Unable to delete gist comment on " + url))
+    end
+
+    p
+
+primitive GistCommentJsonConverter is req.JsonConverter[GistComment]
+  """
+  Converts a JSON object from the gist comments API into a GistComment.
+  """
+  fun apply(json: JsonNav, creds: req.Credentials): GistComment ? =>
+    let id = json("id").as_i64()?
+    let node_id = json("node_id").as_string()?
+    let url = json("url").as_string()?
+    let body = json("body").as_string()?
+    let user = try UserJsonConverter(json("user"), creds)? else None end
+    let author_association = json("author_association").as_string()?
+    let created_at = json("created_at").as_string()?
+    let updated_at = json("updated_at").as_string()?
+
+    GistComment(creds,
+      id,
+      node_id,
+      url,
+      body,
+      user,
+      author_association,
+      created_at,
+      updated_at)

--- a/github_rest_api/gist_commit.pony
+++ b/github_rest_api/gist_commit.pony
@@ -1,0 +1,72 @@
+use "json"
+use req = "request"
+
+class val GistChangeStatus
+  """
+  The number of additions, deletions, and total changes in a gist commit.
+  """
+  let additions: I64
+  let deletions: I64
+  let total: I64
+
+  new val create(additions': I64, deletions': I64, total': I64) =>
+    additions = additions'
+    deletions = deletions'
+    total = total'
+
+primitive GistChangeStatusJsonConverter is req.JsonConverter[GistChangeStatus]
+  """
+  Converts a JSON object representing a gist commit's change_status into a
+  GistChangeStatus.
+  """
+  fun apply(json: JsonNav, creds: req.Credentials): GistChangeStatus ? =>
+    let additions = json("additions").as_i64()?
+    let deletions = json("deletions").as_i64()?
+    let total = json("total").as_i64()?
+
+    GistChangeStatus(additions, deletions, total)
+
+class val GistCommit
+  """
+  A single commit in a gist's history. Contains the version SHA, commit
+  timestamp, change statistics, and the user who made the commit.
+  """
+  let _creds: req.Credentials
+  let version: String
+  let url: String
+  let committed_at: String
+  let change_status: GistChangeStatus
+  let user: (User | None)
+
+  new val create(creds: req.Credentials,
+    version': String,
+    url': String,
+    committed_at': String,
+    change_status': GistChangeStatus,
+    user': (User | None))
+  =>
+    _creds = creds
+    version = version'
+    url = url'
+    committed_at = committed_at'
+    change_status = change_status'
+    user = user'
+
+primitive GistCommitJsonConverter is req.JsonConverter[GistCommit]
+  """
+  Converts a JSON object from the gist commits endpoint into a GistCommit.
+  """
+  fun apply(json: JsonNav, creds: req.Credentials): GistCommit ? =>
+    let version = json("version").as_string()?
+    let url = json("url").as_string()?
+    let committed_at = json("committed_at").as_string()?
+    let change_status =
+      GistChangeStatusJsonConverter(json("change_status"), creds)?
+    let user = try UserJsonConverter(json("user"), creds)? else None end
+
+    GistCommit(creds,
+      version,
+      url,
+      committed_at,
+      change_status,
+      user)

--- a/github_rest_api/gist_file.pony
+++ b/github_rest_api/gist_file.pony
@@ -1,0 +1,64 @@
+use "json"
+use req = "request"
+
+class val GistFile
+  """
+  A single file within a gist. Contains the file's metadata and optionally its
+  content. The `content`, `encoding`, and `truncated` fields are only present
+  when fetching a single gist; list endpoints omit them.
+
+  The `content_type` field corresponds to the `"type"` key in the GitHub JSON
+  response (renamed because `type` is a Pony keyword).
+  """
+  let filename: String
+  let content_type: String
+  let language: (String | None)
+  let raw_url: String
+  let size: I64
+  let content: (String | None)
+  let encoding: (String | None)
+  let truncated: (Bool | None)
+
+  new val create(filename': String,
+    content_type': String,
+    language': (String | None),
+    raw_url': String,
+    size': I64,
+    content': (String | None) = None,
+    encoding': (String | None) = None,
+    truncated': (Bool | None) = None)
+  =>
+    filename = filename'
+    content_type = content_type'
+    language = language'
+    raw_url = raw_url'
+    size = size'
+    content = content'
+    encoding = encoding'
+    truncated = truncated'
+
+primitive GistFileJsonConverter is req.JsonConverter[GistFile]
+  """
+  Converts a JSON object representing a single gist file into a GistFile.
+  Optional fields that may be absent in list responses are extracted with
+  try/else None.
+  """
+  fun apply(json: JsonNav, creds: req.Credentials): GistFile ? =>
+    let filename = json("filename").as_string()?
+    let content_type = json("type").as_string()?
+    let language = JsonNavUtil.string_or_none(json("language"))?
+    let raw_url = json("raw_url").as_string()?
+    let size = json("size").as_i64()?
+    let content = try JsonNavUtil.string_or_none(json("content"))? else None end
+    let encoding =
+      try JsonNavUtil.string_or_none(json("encoding"))? else None end
+    let truncated = try json("truncated").as_bool()? else None end
+
+    GistFile(filename,
+      content_type,
+      language,
+      raw_url,
+      size,
+      content,
+      encoding,
+      truncated)

--- a/github_rest_api/gist_file_update.pony
+++ b/github_rest_api/gist_file_update.pony
@@ -1,0 +1,34 @@
+class val GistFileEdit
+  """
+  Describes an edit to an existing gist file's content. Serializes to
+  `{"content": "..."}` in the update request body.
+  """
+  let content: String
+
+  new val create(content': String) =>
+    content = content'
+
+class val GistFileRename
+  """
+  Describes a rename of an existing gist file, optionally with new content.
+  Serializes to `{"filename": "..."}` or
+  `{"filename": "...", "content": "..."}` in the update request body.
+  """
+  let filename: String
+  let content: (String | None)
+
+  new val create(filename': String, content': (String | None) = None) =>
+    filename = filename'
+    content = content'
+
+primitive GistFileDelete
+  """
+  Marks a gist file for deletion. Serializes to `null` in the update request
+  body's files object.
+  """
+
+type GistFileUpdate is (GistFileEdit | GistFileRename | GistFileDelete)
+  """
+  Union of possible file-level changes when updating a gist. Each variant
+  controls what JSON is emitted for that filename in the PATCH request body.
+  """

--- a/github_rest_api/github.pony
+++ b/github_rest_api/github.pony
@@ -13,10 +13,64 @@ class val GitHub
   fun get_repo(owner: String, repo: String)
     : Promise[RepositoryOrError]
   =>
+    """
+    Fetches a repository by owner and name.
+    """
     GetRepository(owner, repo, _creds)
 
   fun get_org_repos(org: String)
     : Promise[(PaginatedList[Repository] | req.RequestError)]
   =>
+    """
+    Lists all repositories in a GitHub organization.
+    """
     GetOrganizationRepositories(org, _creds)
+
+  fun get_gist(gist_id: String): Promise[GistOrError] =>
+    """
+    Fetches a single gist by its ID.
+    """
+    GetGist(gist_id, _creds)
+
+  fun create_gist(files: Array[(String, String)] val,
+    description: (String | None) = None,
+    is_public: Bool = false): Promise[GistOrError]
+  =>
+    """
+    Creates a new gist with the given files. Each entry in `files` is a
+    (filename, content) pair.
+    """
+    CreateGist(files, _creds, description, is_public)
+
+  fun get_user_gists()
+    : Promise[(PaginatedList[Gist] | req.RequestError)]
+  =>
+    """
+    Lists the authenticated user's gists.
+    """
+    GetUserGists(_creds)
+
+  fun get_public_gists()
+    : Promise[(PaginatedList[Gist] | req.RequestError)]
+  =>
+    """
+    Lists public gists.
+    """
+    GetPublicGists(_creds)
+
+  fun get_starred_gists()
+    : Promise[(PaginatedList[Gist] | req.RequestError)]
+  =>
+    """
+    Lists the authenticated user's starred gists.
+    """
+    GetStarredGists(_creds)
+
+  fun get_username_gists(username: String)
+    : Promise[(PaginatedList[Gist] | req.RequestError)]
+  =>
+    """
+    Lists a specific user's public gists.
+    """
+    GetUsernameGists(username, _creds)
 

--- a/github_rest_api/request/http_check.pony
+++ b/github_rest_api/request/http_check.pony
@@ -1,0 +1,117 @@
+use "http"
+use "net"
+use "ssl/net"
+use "promises"
+
+interface tag CheckResultReceiver
+  """
+  Receives the result of an HTTP status check where 204 means true and 404
+  means false. Used for endpoints like "is this gist starred?" that indicate
+  their answer via status code rather than a response body.
+  """
+  be success(value: Bool)
+  be failure(status: U16, response_body: String, message: String)
+
+type BoolOrError is (Bool | RequestError)
+
+actor BoolResultReceiver
+  """
+  Bridges a CheckResultReceiver to a Promise[BoolOrError], fulfilling the
+  promise with true, false, or a RequestError.
+  """
+  let _p: Promise[BoolOrError]
+
+  new create(p: Promise[BoolOrError]) =>
+    _p = p
+
+  be success(value: Bool) =>
+    _p(value)
+
+  be failure(status: U16, response_body: String, message: String) =>
+    _p(RequestError(status, response_body, message))
+
+class HTTPCheck
+  """
+  Sends an HTTP GET request and interprets the status code as a boolean: 204
+  means true, 404 means false, and any other status is treated as a failure.
+  Used for GitHub API endpoints that answer yes/no questions via status codes
+  (e.g., checking whether a gist is starred).
+  """
+  let _auth: TCPConnectAuth
+  let _sslctx: (SSLContext | None)
+
+  new create(auth: TCPConnectAuth) =>
+    _auth = auth
+
+    _sslctx = try
+      recover val
+        SSLContext.>set_client_verify(true).>set_authority(None)?
+      end
+    else
+      None
+    end
+
+  fun ref apply(url: String,
+    receiver: CheckResultReceiver,
+    auth_token: (String | None) = None) ?
+  =>
+    let valid_url = URL.valid(url)?
+    let r = RequestFactory("GET", valid_url, auth_token)
+
+    let handler_factory = HTTPCheckHandlerFactory(receiver)
+    let client = HTTPClient(_auth, handler_factory, _sslctx)
+    client(consume r)?
+
+class HTTPCheckHandlerFactory is HandlerFactory
+  let _receiver: CheckResultReceiver
+
+  new val create(receiver: CheckResultReceiver) =>
+    _receiver = receiver
+
+  fun apply(session: HTTPSession tag): HTTPHandler ref^ =>
+    HTTPCheckHandler(_receiver)
+
+class HTTPCheckHandler is HTTPHandler
+  let _receiver: CheckResultReceiver
+  var _payload_body: Array[U8] iso = recover Array[U8] end
+  var _status: U16 = 0
+
+  new create(receiver: CheckResultReceiver) =>
+    _receiver = receiver
+
+  fun ref apply(payload: Payload val) =>
+    _status = payload.status
+
+    try
+      for bs in payload.body()?.values() do
+        _payload_body.append(bs)
+      end
+    end
+
+    if payload.transfer_mode is OneshotTransfer then
+      finished()
+    end
+
+  fun ref chunk(data: ByteSeq) =>
+    _payload_body.append(data)
+
+  fun ref failed(reason: HTTPFailureReason) =>
+    let msg = match reason
+    | AuthFailed => "Authorization failure"
+    | ConnectFailed => "Unable to connect"
+    | ConnectionClosed => "Connection was prematurely closed"
+    end
+
+    _receiver.failure(_status, "", consume msg)
+
+  fun ref finished() =>
+    if _status == 204 then
+      _receiver.success(true)
+    elseif _status == 404 then
+      _receiver.success(false)
+    else
+      let x = _payload_body = recover Array[U8] end
+      let y = String.from_iso_array(consume x)
+
+      _receiver.failure(_status, consume y, "")
+    end

--- a/github_rest_api/request/http_patch.pony
+++ b/github_rest_api/request/http_patch.pony
@@ -1,0 +1,92 @@
+use "http"
+use "json"
+use "net"
+use "ssl/net"
+
+class HTTPPatch
+  """
+  Sends an HTTP PATCH request with a JSON body and expects a 200 response
+  containing JSON. Used for updating existing resources in the GitHub API.
+  """
+  let _auth: TCPConnectAuth
+  let _sslctx: (SSLContext | None)
+
+  new create(auth: TCPConnectAuth) =>
+    _auth = auth
+
+    _sslctx = try
+      recover val
+        SSLContext.>set_client_verify(true).>set_authority(None)?
+      end
+    else
+      None
+    end
+
+  fun ref apply(url: String,
+    body: String,
+    receiver: PostResultReceiver,
+    auth_token: (String | None) = None) ?
+  =>
+    let valid_url = URL.valid(url)?
+    let r = RequestFactory("PATCH", valid_url, auth_token)
+    r.add_chunk(body)
+
+    let handler_factory = HTTPPatchHandlerFactory(receiver)
+    let client = HTTPClient(_auth, handler_factory, _sslctx)
+    client(consume r)?
+
+class HTTPPatchHandlerFactory is HandlerFactory
+  let _receiver: PostResultReceiver
+
+  new val create(receiver: PostResultReceiver) =>
+    _receiver = receiver
+
+  fun apply(session: HTTPSession tag): HTTPHandler ref^ =>
+    HTTPPatchHandler(_receiver)
+
+class HTTPPatchHandler is HTTPHandler
+  let _receiver: PostResultReceiver
+  var _payload_body: Array[U8] iso = recover Array[U8] end
+  var _status: U16 = 0
+
+  new create(receiver: PostResultReceiver) =>
+    _receiver = receiver
+
+  fun ref apply(payload: Payload val) =>
+    _status = payload.status
+
+    try
+      for bs in payload.body()?.values() do
+        _payload_body.append(bs)
+      end
+    end
+
+    if payload.transfer_mode is OneshotTransfer then
+      finished()
+    end
+
+  fun ref chunk(data: ByteSeq) =>
+    _payload_body.append(data)
+
+  fun ref failed(reason: HTTPFailureReason) =>
+    let msg = match reason
+    | AuthFailed => "Authorization failure"
+    | ConnectFailed => "Unable to connect"
+    | ConnectionClosed => "Connection was prematurely closed"
+    end
+
+    _receiver.failure(_status, "", consume msg)
+
+  fun ref finished() =>
+    let x = _payload_body = recover Array[U8] end
+    let y = String.from_iso_array(consume x)
+
+    if _status == 200 then
+      match JsonParser.parse(consume y)
+      | let json: JsonValue => _receiver.success(JsonNav(json))
+      | let _: JsonParseError => _receiver.failure(_status, "",
+        "Failed to parse response")
+      end
+    else
+      _receiver.failure(_status, consume y, "")
+    end

--- a/github_rest_api/request/http_put.pony
+++ b/github_rest_api/request/http_put.pony
@@ -1,0 +1,87 @@
+use "http"
+use "net"
+use "ssl/net"
+
+class HTTPPut
+  """
+  Sends an HTTP PUT request with no body and expects a 204 response. Used for
+  actions like starring a gist where the request carries no payload and success
+  is indicated by 204 No Content.
+  """
+  let _auth: TCPConnectAuth
+  let _sslctx: (SSLContext | None)
+
+  new create(auth: TCPConnectAuth) =>
+    _auth = auth
+
+    _sslctx = try
+      recover val
+        SSLContext.>set_client_verify(true).>set_authority(None)?
+      end
+    else
+      None
+    end
+
+  fun ref apply(url: String,
+    receiver: DeleteResultReceiver,
+    auth_token: (String | None) = None) ?
+  =>
+    let valid_url = URL.valid(url)?
+    let r = RequestFactory("PUT", valid_url, auth_token)
+    r("Content-Length") = "0"
+
+    let handler_factory = HTTPPutHandlerFactory(receiver)
+    let client = HTTPClient(_auth, handler_factory, _sslctx)
+    client(consume r)?
+
+class HTTPPutHandlerFactory is HandlerFactory
+  let _receiver: DeleteResultReceiver
+
+  new val create(receiver: DeleteResultReceiver) =>
+    _receiver = receiver
+
+  fun apply(session: HTTPSession tag): HTTPHandler ref^ =>
+    HTTPPutHandler(_receiver)
+
+class HTTPPutHandler is HTTPHandler
+  let _receiver: DeleteResultReceiver
+  var _payload_body: Array[U8] iso = recover Array[U8] end
+  var _status: U16 = 0
+
+  new create(receiver: DeleteResultReceiver) =>
+    _receiver = receiver
+
+  fun ref apply(payload: Payload val) =>
+    _status = payload.status
+
+    try
+      for bs in payload.body()?.values() do
+        _payload_body.append(bs)
+      end
+    end
+
+    if payload.transfer_mode is OneshotTransfer then
+      finished()
+    end
+
+  fun ref chunk(data: ByteSeq) =>
+    _payload_body.append(data)
+
+  fun ref failed(reason: HTTPFailureReason) =>
+    let msg = match reason
+    | AuthFailed => "Authorization failure"
+    | ConnectFailed => "Unable to connect"
+    | ConnectionClosed => "Connection was prematurely closed"
+    end
+
+    _receiver.failure(_status, "", consume msg)
+
+  fun ref finished() =>
+    if _status == 204 then
+      _receiver.success()
+    else
+      let x = _payload_body = recover Array[U8] end
+      let y = String.from_iso_array(consume x)
+
+      _receiver.failure(_status, consume y, "")
+    end


### PR DESCRIPTION
Implements complete coverage of the GitHub Gist API (20 endpoints) for #70.

New models: Gist, GistFile, GistFileEdit, GistFileRename, GistFileDelete, GistCommit, GistChangeStatus, GistComment.

15 gist operations (CRUD, 4 list variants, revision, fork, list forks, list commits, star/unstar/check star) and 5 gist comment operations (CRUD + list). All list operations support pagination.

3 new HTTP infrastructure classes close the documented PATCH/PUT gaps: HTTPPatch (PATCH expecting 200), HTTPPut (PUT expecting 204), HTTPCheck (GET returning Bool via 204/404).

10 new example programs (functional + OO pairs for get, create, list, comments, star) and an examples/README.md covering all 33 examples.