### PR TITLE
Build examples in parallel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,10 +53,14 @@ $(tests_binary): $(SOURCE_FILES) | $(BUILD_DIR)
 	$(GET_DEPENDENCIES_WITH)
 	$(PONYC) -o $(BUILD_DIR) $(SRC_DIR)
 
-build-examples: $(EXAMPLES_BINARIES)
+build-examples:
+	$(GET_DEPENDENCIES_WITH)
+	@$(MAKE) -j$(shell nproc) _build_examples GET_DEPENDENCIES_WITH=true
+
+_build_examples: $(EXAMPLES_BINARIES)
 
 $(EXAMPLES_BINARIES): $(BUILD_DIR)/%: $(SOURCE_FILES) $(EXAMPLES_SOURCE_FILES) | $(BUILD_DIR)
-	BUILD_DIR=$(mkfile_path)$(BUILD_DIR) make -C $(EXAMPLES_DIR)/$*
+	BUILD_DIR=$(mkfile_path)$(BUILD_DIR) $(MAKE) -C $(EXAMPLES_DIR)/$*
 
 clean:
 	$(CLEAN_DEPENDENCIES_WITH)
@@ -77,4 +81,4 @@ all: test
 $(BUILD_DIR):
 	mkdir -p $(BUILD_DIR)
 
-.PHONY: all build-examples clean TAGS test
+.PHONY: all build-examples _build_examples clean TAGS test


### PR DESCRIPTION
Restructure build-examples to fetch corral dependencies once at the
top level, then spawn a parallel sub-make for the actual compilations.
Passing `GET_DEPENDENCIES_WITH=true` to the sub-make overrides the
variable in each example's Makefile, skipping redundant corral fetch
calls. This turns N+1 sequential fetches into 1 fetch followed by N
parallel compilations.

Also switches the example sub-make invocation from literal `make` to
`$(MAKE)` so command-line variable overrides propagate correctly
through recursive make.