### PR TITLE
Add docstrings to pre-existing public API elements

### DIFF
--- a/github_rest_api/asset.pony
+++ b/github_rest_api/asset.pony
@@ -2,6 +2,10 @@ use "json"
 use req = "request"
 
 class val Asset
+  """
+  A file attached to a GitHub release. Contains the asset's metadata including
+  its name, size, download count, and the browser download URL.
+  """
   let _creds: req.Credentials
 
   let id: I64
@@ -50,6 +54,9 @@ class val Asset
     browser_download_url = browser_download_url'
 
 primitive AssetJsonConverter is req.JsonConverter[Asset]
+  """
+  Converts a JSON object into an Asset.
+  """
   fun apply(json: JsonNav, creds: req.Credentials): Asset ? =>
     let id = json("id").as_i64()?
     let node_id = json("node_id").as_string()?

--- a/github_rest_api/commit.pony
+++ b/github_rest_api/commit.pony
@@ -6,6 +6,10 @@ use ut = "uri/template"
 type CommitOrError is (Commit | req.RequestError)
 
 class val Commit
+  """
+  A GitHub commit, containing its SHA, changed files, and nested git commit
+  data (author, committer, message).
+  """
   let _creds: req.Credentials
   let sha: String
   let files: Array[CommitFile] val
@@ -31,6 +35,9 @@ class val Commit
     comments_url = comments_url'
 
 primitive GetCommit
+  """
+  Fetches a single commit by owner, repo, and SHA.
+  """
   fun apply(owner: String,
     repo: String,
     sha: String,
@@ -65,6 +72,9 @@ primitive GetCommit
     p
 
 primitive CommitJsonConverter is req.JsonConverter[Commit]
+  """
+  Converts a JSON object from the commits API into a Commit.
+  """
   fun apply(json: JsonNav, creds: req.Credentials): Commit ? =>
     let sha = json("sha").as_string()?
 

--- a/github_rest_api/commit_file.pony
+++ b/github_rest_api/commit_file.pony
@@ -3,6 +3,9 @@ use "promises"
 use req = "request"
 
 class val CommitFile
+  """
+  A file changed in a commit, with its SHA, modification status, and filename.
+  """
   let _creds: req.Credentials
   let sha: String
   let status: String
@@ -19,6 +22,9 @@ class val CommitFile
     filename = filename'
 
 primitive CommitFileJsonConverter is req.JsonConverter[CommitFile]
+  """
+  Converts a JSON object into a CommitFile.
+  """
   fun apply(json: JsonNav,
     creds: req.Credentials): CommitFile ?
   =>

--- a/github_rest_api/git_commit.pony
+++ b/github_rest_api/git_commit.pony
@@ -2,6 +2,11 @@ use "json"
 use req = "request"
 
 class val GitCommit
+  """
+  The git commit data within a GitHub commit, containing author, committer,
+  message, and the git-level URL. This is the nested `commit` object inside the
+  top-level Commit response.
+  """
   let _creds: req.Credentials
   let author: GitPerson
   let committer: GitPerson
@@ -21,6 +26,9 @@ class val GitCommit
     url = url'
 
 primitive GitCommitJsonConverter is req.JsonConverter[GitCommit]
+  """
+  Converts a JSON object into a GitCommit.
+  """
   fun apply(json: JsonNav, creds: req.Credentials): GitCommit ? =>
     let author = GitPersonJsonConverter(json("author"), creds)?
     let committer = GitPersonJsonConverter(json("committer"), creds)?

--- a/github_rest_api/git_person.pony
+++ b/github_rest_api/git_person.pony
@@ -2,6 +2,9 @@ use "json"
 use req = "request"
 
 class val GitPerson
+  """
+  A git author or committer identity with a name and email address.
+  """
   let name: String
   let email: String
 
@@ -10,6 +13,9 @@ class val GitPerson
     email = email'
 
 primitive GitPersonJsonConverter is req.JsonConverter[GitPerson]
+  """
+  Converts a JSON object into a GitPerson.
+  """
   fun apply(json: JsonNav, creds: req.Credentials): GitPerson ? =>
     let name = json("name").as_string()?
     let email = json("email").as_string()?

--- a/github_rest_api/github.pony
+++ b/github_rest_api/github.pony
@@ -5,6 +5,12 @@ use req = "request"
 type RepositoryOrError is (Repository | req.RequestError)
 
 class val GitHub
+  """
+  Entry point for all GitHub REST API operations. Holds credentials and
+  authentication context used to issue requests. Each method corresponds to a
+  top-level API operation; returned models provide convenience methods for
+  further related calls.
+  """
   let _creds: req.Credentials
 
   new val create(creds: req.Credentials) =>

--- a/github_rest_api/github_rest_api.pony
+++ b/github_rest_api/github_rest_api.pony
@@ -1,3 +1,20 @@
 """
-Package documentation goes here
+A Pony library for interacting with the GitHub REST API.
+
+Start by creating a `GitHub` instance with your credentials, then use its
+methods to fetch repositories, issues, gists, and other resources. All API
+operations return `Promise`-based results as `(Model | RequestError)` unions.
+
+```pony
+use "github_rest_api"
+use "github_rest_api/request"
+
+let creds = Credentials(auth, "your-token-here")
+let github = GitHub(creds)
+github.get_repo("ponylang", "ponyc")
+```
+
+Returned model objects provide convenience methods for related API calls —
+for example, a `Repository` can create labels and releases, and an `Issue`
+can create comments.
 """

--- a/github_rest_api/issue.pony
+++ b/github_rest_api/issue.pony
@@ -6,6 +6,11 @@ use ut = "uri/template"
 type IssueOrError is (Issue | req.RequestError)
 
 class val Issue
+  """
+  A GitHub issue. Provides convenience methods to create comments and list
+  existing comments on this issue. The `pull_request` field is present when the
+  issue is actually a pull request.
+  """
   let _creds: req.Credentials
 
   let number: I64
@@ -55,12 +60,21 @@ class val Issue
     pull_request = pull_request'
 
   fun create_comment(comment: String): Promise[IssueCommentOrError] =>
+    """
+    Creates a new comment on this issue.
+    """
     CreateIssueComment.by_url(comments_url, comment, _creds)
 
   fun get_comments(): Promise[IssueCommentsOrError] =>
+    """
+    Fetches all comments on this issue.
+    """
     GetIssueComments.by_url(comments_url, _creds)
 
 primitive GetIssue
+  """
+  Fetches a single issue by owner, repo, and number.
+  """
   fun apply(owner: String,
     repo: String,
     number: I64,
@@ -95,6 +109,10 @@ primitive GetIssue
     p
 
 primitive GetRepositoryIssues
+  """
+  Lists issues in a repository as a paginated list, optionally filtered by
+  labels and state.
+  """
   fun apply(owner: String,
     repo: String,
     creds: req.Credentials,
@@ -141,6 +159,9 @@ primitive GetRepositoryIssues
 
 
 primitive IssueJsonConverter is req.JsonConverter[Issue]
+  """
+  Converts a JSON object from the issues API into an Issue.
+  """
   fun apply(json: JsonNav, creds: req.Credentials): Issue ? =>
     let url = json("url").as_string()?
     let respository_url = json("repository_url").as_string()?

--- a/github_rest_api/issue_comment.pony
+++ b/github_rest_api/issue_comment.pony
@@ -9,6 +9,9 @@ type IssueComments is Array[IssueComment] val
 type IssueCommentsOrError is (IssueComments | req.RequestError)
 
 class val IssueComment
+  """
+  A comment on a GitHub issue.
+  """
   let _creds: req.Credentials
   let body: String
   let url: String
@@ -28,6 +31,9 @@ class val IssueComment
     issue_url = issue_url'
 
 primitive CreateIssueComment
+  """
+  Creates a new comment on an issue.
+  """
   fun apply(owner: String,
     repo: String,
     number: I64,
@@ -68,6 +74,9 @@ primitive CreateIssueComment
     p
 
 primitive GetIssueComments
+  """
+  Fetches all comments on an issue.
+  """
   fun apply(owner: String,
     repo: String,
     number: I64,
@@ -102,6 +111,10 @@ primitive GetIssueComments
     p
 
 primitive IssueCommentsURL
+  """
+  Builds the URL for an issue's comments endpoint from owner, repo, and issue
+  number.
+  """
   fun apply(owner: String, repo: String, number: I64)
     : (String | ut.URITemplateParseError)
   =>
@@ -118,6 +131,9 @@ primitive IssueCommentsURL
     end
 
 primitive IssueCommentJsonConverter is req.JsonConverter[IssueComment]
+  """
+  Converts a JSON object into an IssueComment.
+  """
   fun apply(json: JsonNav,
     creds: req.Credentials): IssueComment ?
   =>
@@ -129,6 +145,9 @@ primitive IssueCommentJsonConverter is req.JsonConverter[IssueComment]
     IssueComment(creds, body, url, html_url, issue_url)
 
 primitive IssueCommentsJsonConverter is req.JsonConverter[Array[IssueComment] val]
+  """
+  Converts a JSON array of issue comment objects into an Array of IssueComment.
+  """
   fun apply(json: JsonNav,
     creds: req.Credentials): Array[IssueComment] val ?
   =>

--- a/github_rest_api/issue_pull_request.pony
+++ b/github_rest_api/issue_pull_request.pony
@@ -29,6 +29,9 @@ class val IssuePullRequest
     merged_at = merged_at'
 
 primitive IssuePullRequestJsonConverter is req.JsonConverter[IssuePullRequest]
+  """
+  Converts a JSON object into an IssuePullRequest.
+  """
   fun apply(json: JsonNav, creds: req.Credentials): IssuePullRequest ? =>
     let url = json("url").as_string()?
     let html_url = json("html_url").as_string()?

--- a/github_rest_api/label.pony
+++ b/github_rest_api/label.pony
@@ -6,6 +6,9 @@ use ut = "uri/template"
 type LabelOrError is (Label | req.RequestError)
 
 class val Label
+  """
+  A label on a GitHub repository, with its name, color, and description.
+  """
   let _creds: req.Credentials
   let id: I64
   let node_id: String
@@ -34,6 +37,9 @@ class val Label
     description = description'
 
 primitive CreateLabel
+  """
+  Creates a new label on a repository.
+  """
   fun apply(owner: String,
     repo: String,
     name: String,
@@ -87,6 +93,9 @@ primitive CreateLabel
     p
 
 primitive DeleteLabel
+  """
+  Deletes a label from a repository.
+  """
   fun apply(owner: String,
     repo: String,
     name: String,
@@ -126,6 +135,9 @@ primitive DeleteLabel
     p
 
 primitive LabelJsonConverter is req.JsonConverter[Label]
+  """
+  Converts a JSON object into a Label.
+  """
   fun apply(json: JsonNav, creds: req.Credentials): Label ? =>
     let id = json("id").as_i64()?
     let node_id = json("node_id").as_string()?

--- a/github_rest_api/license.pony
+++ b/github_rest_api/license.pony
@@ -2,6 +2,10 @@ use "json"
 use req = "request"
 
 class val License
+  """
+  A repository license as returned by the GitHub REST API. Contains the
+  license's SPDX identifier, display name, and key.
+  """
   let _creds: req.Credentials
   let node_id: String
   let name: String
@@ -24,6 +28,9 @@ class val License
     url = url'
 
 primitive LicenseJsonConverter is req.JsonConverter[License]
+  """
+  Converts a JSON object into a License.
+  """
   fun apply(json: JsonNav, creds: req.Credentials): License ? =>
     let node_id = json("node_id").as_string()?
     let name = json("name").as_string()?

--- a/github_rest_api/pull_request.pony
+++ b/github_rest_api/pull_request.pony
@@ -7,6 +7,10 @@ use ut = "uri/template"
 type PullRequestOrError is (PullRequest | req.RequestError)
 
 class val PullRequest
+  """
+  A GitHub pull request. Provides a convenience method to fetch the files
+  changed in this pull request.
+  """
   let _creds: req.Credentials
 
   let number: I64
@@ -44,9 +48,15 @@ class val PullRequest
     files_url = url + "/files"
 
   fun get_files(): Promise[PullRequestFilesOrError] =>
+    """
+    Fetches the files changed in this pull request.
+    """
     GetPullRequestFiles.by_url(files_url, _creds)
 
 primitive GetPullRequest
+  """
+  Fetches a single pull request by owner, repo, and number.
+  """
   fun apply(owner: String,
     repo: String,
     number: I64,
@@ -84,6 +94,9 @@ primitive GetPullRequest
     p
 
 primitive PullRequestJsonConverter is req.JsonConverter[PullRequest]
+  """
+  Converts a JSON object from the pulls API into a PullRequest.
+  """
   fun apply(json: JsonNav, creds: req.Credentials): PullRequest ? =>
     let number = json("number").as_i64()?
     let title = json("title").as_string()?

--- a/github_rest_api/pull_request_base.pony
+++ b/github_rest_api/pull_request_base.pony
@@ -2,6 +2,10 @@ use "json"
 use req = "request"
 
 class val PullRequestBase
+  """
+  The head or base ref of a pull request, containing its label, ref name, SHA,
+  owner, and associated repository.
+  """
   let _creds: req.Credentials
   let label: String
   let reference: String
@@ -24,6 +28,9 @@ class val PullRequestBase
     repo = repo'
 
 primitive PullRequestBaseJsonConverter is req.JsonConverter[PullRequestBase]
+  """
+  Converts a JSON object into a PullRequestBase.
+  """
   fun apply(json: JsonNav, creds: req.Credentials): PullRequestBase ? =>
     let label = json("label").as_string()?
     let reference = json("ref").as_string()?

--- a/github_rest_api/pull_request_file.pony
+++ b/github_rest_api/pull_request_file.pony
@@ -8,6 +8,9 @@ type PullRequestFiles is Array[PullRequestFile] val
 type PullRequestFilesOrError is (PullRequestFiles | req.RequestError)
 
 class val PullRequestFile
+  """
+  A file changed in a pull request. Currently only captures the filename.
+  """
   let _creds: req.Credentials
   let filename: String
 
@@ -16,6 +19,9 @@ class val PullRequestFile
     filename = filename'
 
 primitive GetPullRequestFiles
+  """
+  Fetches the list of files changed in a pull request.
+  """
   fun apply(owner: String,
     repo: String,
     number: I64,
@@ -57,6 +63,10 @@ primitive GetPullRequestFiles
 
 primitive PullRequestFilesJsonConverter is
   req.JsonConverter[Array[PullRequestFile] val]
+  """
+  Converts a JSON array of pull request file objects into an Array of
+  PullRequestFile.
+  """
   fun apply(json: JsonNav,
     creds: req.Credentials): Array[PullRequestFile] val ?
   =>

--- a/github_rest_api/release.pony
+++ b/github_rest_api/release.pony
@@ -6,6 +6,10 @@ use ut = "uri/template"
 type ReleaseOrError is (Release | req.RequestError)
 
 class val Release
+  """
+  A GitHub release, containing its tag, target commit, release notes body,
+  draft/prerelease status, and associated assets.
+  """
   let _creds: req.Credentials
 
   let id: I64
@@ -70,6 +74,9 @@ class val Release
     zipball_url = zipball_url'
 
 primitive CreateRelease
+  """
+  Creates a new release on a repository.
+  """
   fun apply(owner: String,
     repo: String,
     tag_name: String,
@@ -137,6 +144,9 @@ primitive CreateRelease
     p
 
 primitive ReleaseJsonConverter is req.JsonConverter[Release]
+  """
+  Converts a JSON object from the releases API into a Release.
+  """
   fun apply(json: JsonNav, creds: req.Credentials): Release ? =>
     let id = json("id").as_i64()?
     let node_id = json("node_id").as_string()?

--- a/github_rest_api/repository.pony
+++ b/github_rest_api/repository.pony
@@ -5,6 +5,12 @@ use req = "request"
 use ut = "uri/template"
 
 class val Repository
+  """
+  A GitHub repository. Contains the repository's metadata, feature flags,
+  counts, and API/clone URLs. Provides convenience methods for creating labels
+  and releases, deleting labels, and fetching commits, issues, and pull
+  requests.
+  """
   let _creds: req.Credentials
   let id: I64
   let node_id: String
@@ -243,6 +249,9 @@ class val Repository
     color: (String | None) = None,
     label_description: (String | None) = None): Promise[LabelOrError]
   =>
+    """
+    Creates a new label on this repository.
+    """
     match ut.URITemplateParse(labels_url)
     | let tpl: ut.URITemplate =>
       let u: String val = tpl.expand(ut.URITemplateVariables)
@@ -262,6 +271,9 @@ class val Repository
     draft: Bool = false,
     prerelease: Bool = false): Promise[ReleaseOrError]
   =>
+    """
+    Creates a new release on this repository.
+    """
     match ut.URITemplateParse(releases_url)
     | let tpl: ut.URITemplate =>
       let u: String val = tpl.expand(ut.URITemplateVariables)
@@ -278,6 +290,9 @@ class val Repository
     end
 
   fun delete_label(label_name: String): Promise[req.DeletedOrError] =>
+    """
+    Deletes a label from this repository.
+    """
     match ut.URITemplateParse(labels_url)
     | let tpl: ut.URITemplate =>
       let vars = ut.URITemplateVariables
@@ -289,6 +304,9 @@ class val Repository
     end
 
   fun get_commit(sha: String): Promise[CommitOrError] =>
+    """
+    Fetches a commit from this repository by its SHA.
+    """
     match ut.URITemplateParse(commits_url)
     | let tpl: ut.URITemplate =>
       let vars = ut.URITemplateVariables
@@ -300,6 +318,9 @@ class val Repository
     end
 
   fun get_issue(number: I64): Promise[IssueOrError] =>
+    """
+    Fetches a single issue from this repository by its number.
+    """
     match ut.URITemplateParse(issues_url)
     | let tpl: ut.URITemplate =>
       let vars = ut.URITemplateVariables
@@ -313,6 +334,9 @@ class val Repository
   fun get_issues(labels: String = "", state: String = "open")
     : Promise[(PaginatedList[Issue] | req.RequestError)]
   =>
+    """
+    Lists issues in this repository, optionally filtered by labels and state.
+    """
     match ut.URITemplateParse(issues_url)
     | let tpl: ut.URITemplate =>
       let u: String val = tpl.expand(ut.URITemplateVariables)
@@ -331,6 +355,9 @@ class val Repository
     end
 
   fun get_pull_request(number: I64): Promise[PullRequestOrError] =>
+    """
+    Fetches a single pull request from this repository by its number.
+    """
     match ut.URITemplateParse(pulls_url)
     | let tpl: ut.URITemplate =>
       let vars = ut.URITemplateVariables
@@ -343,6 +370,9 @@ class val Repository
     end
 
 primitive GetRepository
+  """
+  Fetches a single repository by owner and name.
+  """
   fun apply(owner: String,
     repo: String,
     creds: req.Credentials): Promise[RepositoryOrError]
@@ -375,6 +405,9 @@ primitive GetRepository
     p
 
 primitive GetRepositoryLabels
+  """
+  Fetches labels for a repository as a paginated list.
+  """
   fun apply(owner: String,
     repo: String,
     creds: req.Credentials): Promise[(PaginatedList[Label] | req.RequestError)]
@@ -410,6 +443,9 @@ primitive GetRepositoryLabels
     p
 
 primitive GetOrganizationRepositories
+  """
+  Lists all repositories in a GitHub organization as a paginated list.
+  """
   fun apply(org: String,
     creds: req.Credentials): Promise[(PaginatedList[Repository] | req.RequestError)]
   =>
@@ -442,6 +478,9 @@ primitive GetOrganizationRepositories
     p
 
 primitive RepositoryJsonConverter is req.JsonConverter[Repository]
+  """
+  Converts a JSON object from the repositories API into a Repository.
+  """
   fun apply(json: JsonNav,
     creds: req.Credentials): Repository ?
   =>

--- a/github_rest_api/user.pony
+++ b/github_rest_api/user.pony
@@ -2,6 +2,11 @@ use "json"
 use req = "request"
 
 class val User
+  """
+  A GitHub user account. Contains the user's login, profile URLs, and account
+  metadata. The `user_type` field corresponds to the `"type"` key in the
+  GitHub JSON response (renamed because `type` is a Pony keyword).
+  """
   let _creds: req.Credentials
   let login: String
   let id: I64
@@ -63,6 +68,9 @@ class val User
     site_admin = site_admin'
 
 primitive UserJsonConverter is req.JsonConverter[User]
+  """
+  Converts a JSON object into a User.
+  """
   fun apply(json: JsonNav, creds: req.Credentials): User ? =>
     let login = json("login").as_string()?
     let id = json("id").as_i64()?


### PR DESCRIPTION
PR #72 (gist API) added docstrings to all new public types and methods, leaving the pre-existing API undocumented. This adds docstrings to all pre-existing public classes, primitives, actors, and their public methods across 20 files to bring the library to a consistent documentation standard.

Also replaces the placeholder package docstring ("Package documentation goes here") with a proper overview that guides users to the `GitHub` entry point and explains the Promise-based return pattern.

The `request/` subpackage is excluded — it's intended to be extracted to its own library and will be documented separately.

Closes #74