### PR TITLE
Fix breakage test event type mismatch

### DIFF
--- a/.github/workflows/breakage-against-ponyc-latest.yml
+++ b/.github/workflows/breakage-against-ponyc-latest.yml
@@ -2,7 +2,7 @@ name: Test against ponyc nightly
 
 on:
   repository_dispatch:
-    types: [shared-docker-linux-builders-updated]
+    types: [shared-docker-builders-updated]
 
 permissions:
   packages: read


### PR DESCRIPTION
The `repository_dispatch` type was `shared-docker-linux-builders-updated`
but the sender (`shared-docker`) dispatches `shared-docker-builders-updated`,
so the breakage test never fired.

Closes #71