### PR TITLE
Add query parameters to GetRepositoryIssues

### DIFF
--- a/.release-notes/add-issue-query-params.md
+++ b/.release-notes/add-issue-query-params.md
@@ -1,0 +1,13 @@
+## Add query parameters to GetRepositoryIssues
+
+`GetRepositoryIssues` and `Repository.get_issues()` now accept `sort`, `direction`, `since`, and `per_page` parameters. All new parameters have defaults that match GitHub's API defaults, so existing callers are unaffected.
+
+The `sort` and `direction` parameters use union types (`IssueSort` and `SortDirection`) for compile-time safety instead of raw strings:
+
+```pony
+// Sort by most recently updated, ascending
+repo.get_issues(where sort = SortUpdated, direction = SortAscending)
+
+// Get issues updated since a timestamp, 50 per page
+repo.get_issues(where since = "2024-01-01T00:00:00Z", per_page = 50)
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ Uses `corral` for dependency management. `make` automatically runs `corral fetch
 github_rest_api/
   github.pony              -- GitHub class (entry point, has get_repo, get_org_repos, gist operations)
   repository.pony          -- Repository model + GetRepository, GetRepositoryLabels
-  issue.pony               -- Issue model + GetIssue, GetRepositoryIssues
+  issue.pony               -- Issue model + GetIssue, GetRepositoryIssues, IssueSort, SortDirection
   issue_pull_request.pony  -- IssuePullRequest model (PR metadata on issues)
   pull_request.pony        -- PullRequest model + GetPullRequest
   pull_request_base.pony   -- PullRequestBase model (head/base refs)
@@ -90,7 +90,7 @@ Models have methods that chain to further API calls:
 - `GitHub.get_gist(gist_id)` -> `Gist`
 - `GitHub.create_gist(files, description, is_public)` -> `Gist`
 - `GitHub.get_user_gists()`, `.get_public_gists()`, `.get_starred_gists()`, `.get_username_gists(username)` -> `PaginatedList[Gist]`
-- `Repository.create_label(...)`, `.create_release(...)`, `.delete_label(...)`, `.get_commit(...)`, `.get_issue(...)`, `.get_issues(...)`, `.get_pull_request(...)`
+- `Repository.create_label(...)`, `.create_release(...)`, `.delete_label(...)`, `.get_commit(...)`, `.get_issue(...)`, `.get_issues(labels, state, sort, direction, since, per_page)`, `.get_pull_request(...)`
 - `Issue.create_comment(...)`, `.get_comments()`
 - `PullRequest.get_files()`
 - `Gist.update_gist(files, description)`, `.delete_gist()`, `.get_revision(sha)`, `.fork()`, `.get_forks()`, `.get_commits()`, `.star()`, `.unstar()`, `.is_starred()`, `.create_comment(body)`, `.get_comments()`


### PR DESCRIPTION
`GetRepositoryIssues` and `Repository.get_issues()` now accept `sort`, `direction`, `since`, and `per_page` parameters. `sort` and `direction` use union types (`IssueSort` and `SortDirection`) for compile-time safety. All new parameters have defaults matching GitHub's API defaults, so existing callers are unaffected.

Closes #56
Design: #54