### PR TITLE
Rename sort criteria primitives to SortBy* prefix

### DIFF
--- a/.release-notes/next-release.md
+++ b/.release-notes/next-release.md
@@ -43,7 +43,7 @@ The `sort` and `direction` parameters use union types (`IssueSort` and `SortDire
 
 ```pony
 // Sort by most recently updated, ascending
-repo.get_issues(where sort = SortUpdated, direction = SortAscending)
+repo.get_issues(where sort = SortByUpdated, direction = SortAscending)
 
 // Get issues updated since a timestamp, 50 per page
 repo.get_issues(where since = "2024-01-01T00:00:00Z", per_page = 50)

--- a/github_rest_api/issue.pony
+++ b/github_rest_api/issue.pony
@@ -5,7 +5,7 @@ use ut = "uri/template"
 
 type IssueOrError is (Issue | req.RequestError)
 
-primitive SortCreated
+primitive SortByCreated
   """
   Sort issues by creation time.
   """
@@ -15,7 +15,7 @@ primitive SortCreated
     """
     "created"
 
-primitive SortUpdated
+primitive SortByUpdated
   """
   Sort issues by last update time.
   """
@@ -25,7 +25,7 @@ primitive SortUpdated
     """
     "updated"
 
-primitive SortComments
+primitive SortByComments
   """
   Sort issues by number of comments.
   """
@@ -35,7 +35,7 @@ primitive SortComments
     """
     "comments"
 
-type IssueSort is (SortCreated | SortUpdated | SortComments)
+type IssueSort is (SortByCreated | SortByUpdated | SortByComments)
   """
   Controls how issues are sorted when listing repository issues.
   """
@@ -182,7 +182,7 @@ primitive GetRepositoryIssues
     creds: req.Credentials,
     labels: String = "",
     state: String = "open",
-    sort: IssueSort = SortCreated,
+    sort: IssueSort = SortByCreated,
     direction: SortDirection = SortDescending,
     since: String = "",
     per_page: (I64 | None) = None): Promise[(PaginatedList[Issue] | req.RequestError)]

--- a/github_rest_api/repository.pony
+++ b/github_rest_api/repository.pony
@@ -333,7 +333,7 @@ class val Repository
 
   fun get_issues(labels: String = "",
     state: String = "open",
-    sort: IssueSort = SortCreated,
+    sort: IssueSort = SortByCreated,
     direction: SortDirection = SortDescending,
     since: String = "",
     per_page: (I64 | None) = None)


### PR DESCRIPTION
Renames `SortCreated`/`SortUpdated`/`SortComments` to `SortByCreated`/`SortByUpdated`/`SortByComments` to disambiguate sort criteria from sort directions (`SortAscending`/`SortDescending`), which share the `Sort` prefix. These types were introduced in PR #85 and have not been released yet, so this is not a breaking change for users.

Also updates the PR #85 release notes to use the new names.

Closes #82