### PR TITLE
Move pr.yml from nightly to release

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -39,7 +39,7 @@ jobs:
     name: Test against recent ponyc release on Linux
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-openssl-3.6.0:nightly
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-openssl-3.6.0:release
     steps:
       - uses: actions/checkout@v4.1.1
       - name: Test


### PR DESCRIPTION
Update CI to test PRs against the latest ponyc release instead of nightly builds.