### PR TITLE
Update courier to 0.2.0

### DIFF
--- a/.release-notes/next-release.md
+++ b/.release-notes/next-release.md
@@ -1,0 +1,8 @@
+
+## Fix potential connection hang when timer event subscription fails
+
+On some platforms, if the operating system cannot allocate resources for a connection timer (e.g., ENOMEM on kqueue or epoll), connections could hang silently instead of reporting an error. Timer subscription failures are now detected and reported as connection failures.
+
+## Require ponyc 0.63.1 or later
+
+github_rest_api now requires ponyc 0.63.1 or later. Older ponyc versions are no longer supported.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,14 @@ All notable changes to this project will be documented in this file. This projec
 
 ### Fixed
 
+- Fix potential connection hang when timer event subscription fails ([PR #118](https://github.com/ponylang/github_rest_api/pull/118))
 
 ### Added
 
 
 ### Changed
 
+- Require ponyc 0.63.1 or later ([PR #118](https://github.com/ponylang/github_rest_api/pull/118))
 
 ## [0.3.2] - 2026-04-07
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Additional API surface and functionality will be added as needed. If you need fu
 
 ## Installation
 
+* Requires ponyc 0.63.1 or later
 * Install [corral](https://github.com/ponylang/corral)
 * `corral add github.com/ponylang/github_rest_api.git --version 0.3.2`
 * `corral fetch` to fetch your dependencies

--- a/corral.json
+++ b/corral.json
@@ -10,7 +10,7 @@
     },
     {
       "locator": "github.com/ponylang/courier.git",
-      "version": "0.1.5"
+      "version": "0.2.0"
     },
     {
       "locator": "github.com/ponylang/uri.git",

--- a/github_rest_api/paginated_list.pony
+++ b/github_rest_api/paginated_list.pony
@@ -241,6 +241,7 @@ actor LinkedJsonRequester is courier.HTTPClientConnectionActor
     | courier.ConnectionFailedTCP => "Unable to connect"
     | courier.ConnectionFailedSSL => "SSL handshake failed"
     | courier.ConnectionFailedTimeout => "Connection timed out"
+    | courier.ConnectionFailedTimerError => "Connect timer failed"
     end
     _receiver.failure(0, "", consume msg)
 

--- a/github_rest_api/request/check_requester.pony
+++ b/github_rest_api/request/check_requester.pony
@@ -118,6 +118,7 @@ actor CheckRequester is courier.HTTPClientConnectionActor
     | courier.ConnectionFailedTCP => "Unable to connect"
     | courier.ConnectionFailedSSL => "SSL handshake failed"
     | courier.ConnectionFailedTimeout => "Connection timed out"
+    | courier.ConnectionFailedTimerError => "Connect timer failed"
     end
     _receiver.failure(0, "", consume msg)
 

--- a/github_rest_api/request/json_requester.pony
+++ b/github_rest_api/request/json_requester.pony
@@ -160,6 +160,7 @@ actor JsonRequester is courier.HTTPClientConnectionActor
     | courier.ConnectionFailedTCP => "Unable to connect"
     | courier.ConnectionFailedSSL => "SSL handshake failed"
     | courier.ConnectionFailedTimeout => "Connection timed out"
+    | courier.ConnectionFailedTimerError => "Connect timer failed"
     end
     _receiver.failure(0, "", consume msg)
 

--- a/github_rest_api/request/no_content_requester.pony
+++ b/github_rest_api/request/no_content_requester.pony
@@ -136,6 +136,7 @@ actor NoContentRequester is courier.HTTPClientConnectionActor
     | courier.ConnectionFailedTCP => "Unable to connect"
     | courier.ConnectionFailedSSL => "SSL handshake failed"
     | courier.ConnectionFailedTimeout => "Connection timed out"
+    | courier.ConnectionFailedTimerError => "Connect timer failed"
     end
     _receiver.failure(0, "", consume msg)
 


### PR DESCRIPTION
Picks up ASIO_ERROR handling for timer subscription failures and requires ponyc 0.63.1 or later.