### PR TITLE
Update courier to 0.2.1

### DIFF
--- a/corral.json
+++ b/corral.json
@@ -10,7 +10,7 @@
     },
     {
       "locator": "github.com/ponylang/courier.git",
-      "version": "0.2.0"
+      "version": "0.2.1"
     },
     {
       "locator": "github.com/ponylang/uri.git",


### PR DESCRIPTION
Picks up the new `on_timer_failure` callback on `HTTPClientLifecycleEventReceiver`. Default no-op keeps existing behavior and github_rest_api doesn't use `set_timer`, so no code changes are required — pure dependency bump.