### PR TITLE
Add AI assistant onboarding note for contributors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,24 @@
 
 A Pony library for interacting with the GitHub REST API. Provides typed models, HTTP request infrastructure, and Promise-based async results.
 
+<!-- contributor-only -->
+## Contributing with an AI assistant
+
+This is a Pony project. The ponylang org maintains a set of LLM coding skills. If your AI assistant isn't set up with them, install them once:
+
+```bash
+git clone https://github.com/ponylang/llm-skills.git
+cd llm-skills
+python install.py
+```
+
+See the [llm-skills README](https://github.com/ponylang/llm-skills) for details and other harnesses.
+
+When you start working on this project, load the `pony-skills` skill — it tells your assistant which Pony skill to use for each task.
+
+Before opening a pull request, read [CONTRIBUTING.md](CONTRIBUTING.md).
+<!-- /contributor-only -->
+
 ## Building and Testing
 
 ```


### PR DESCRIPTION
Adds a contributor-only block to CLAUDE.md pointing new contributors at the ponylang LLM skills — how to install them and to load `pony-skills` when working on the project.