### PR TITLE
Require ponyc 0.64.0 or later

### DIFF
--- a/.github/workflows/generate-documentation.yml
+++ b/.github/workflows/generate-documentation.yml
@@ -21,7 +21,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/library-documentation-action-v2:release
+      image: ghcr.io/ponylang/library-documentation-action-v2:nightly
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -21,7 +21,7 @@ jobs:
     name: Test against recent ponyc release on Linux
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-openssl-3.6.2:release
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-openssl-3.6.2:nightly
     steps:
       - uses: actions/checkout@v6.0.2
       - name: Test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
     needs:
       - pre-artefact-creation
     container:
-      image: ghcr.io/ponylang/library-documentation-action-v2:release
+      image: ghcr.io/ponylang/library-documentation-action-v2:nightly
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2

--- a/.release-notes/require-ponyc-0.64.0.md
+++ b/.release-notes/require-ponyc-0.64.0.md
@@ -1,0 +1,5 @@
+## Require ponyc 0.64.0 or later
+
+github_rest_api now requires ponyc 0.64.0 or later. The previous minimum was 0.63.1.
+
+This is driven by an update to courier 0.3.0, which transitively requires ponyc 0.64.0 via lori 0.15.0 for changes to FFI declaration syntax and the runtime socket API. Older ponyc versions will fail to compile github_rest_api.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Additional API surface and functionality will be added as needed. If you need fu
 
 ## Installation
 
-* Requires ponyc 0.63.1 or later
+* Requires ponyc 0.64.0 or later
 * Install [corral](https://github.com/ponylang/corral)
 * `corral add github.com/ponylang/github_rest_api.git --version 0.4.0`
 * `corral fetch` to fetch your dependencies

--- a/corral.json
+++ b/corral.json
@@ -10,7 +10,7 @@
     },
     {
       "locator": "github.com/ponylang/courier.git",
-      "version": "0.2.1"
+      "version": "0.3.0"
     },
     {
       "locator": "github.com/ponylang/uri.git",


### PR DESCRIPTION
Updates github_rest_api to use courier 0.3.0, which transitively requires ponyc 0.64.0 via lori 0.15.0. Switches CI workflows that pull `shared-docker-ci-standard-builder-with-openssl-3.6.2` and `library-documentation-action-v2` from the `:release` channel to `:nightly` so they can build against the soon-to-be-released ponyc 0.64.0.

Will need a follow-up to switch back to `:release` once ponyc 0.64.0 ships (tracked in ponylang/ponyc#5298).