### PR TITLE
Fix compilation against ponyc 0.65.0

### DIFF
--- a/.github/workflows/generate-documentation.yml
+++ b/.github/workflows/generate-documentation.yml
@@ -21,7 +21,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/library-documentation-action-v2:release
+      image: ghcr.io/ponylang/library-documentation-action-v2:nightly
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -21,7 +21,7 @@ jobs:
     name: Test against recent ponyc release on Linux
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-openssl-3.6.2:release
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-openssl-3.6.2:nightly
     steps:
       - uses: actions/checkout@v6.0.2
       - name: Test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
     needs:
       - pre-artefact-creation
     container:
-      image: ghcr.io/ponylang/library-documentation-action-v2:release
+      image: ghcr.io/ponylang/library-documentation-action-v2:nightly
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2

--- a/.release-notes/fix-compilation-against-ponyc-0.65.0.md
+++ b/.release-notes/fix-compilation-against-ponyc-0.65.0.md
@@ -1,0 +1,3 @@
+## Fix compilation against ponyc 0.65.0
+
+ponyc 0.65.0 changed the standard library `json` package in a way that prevented this library from compiling. github_rest_api now builds against ponyc 0.65.0 and requires ponyc 0.65.0 or later.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Additional API surface and functionality will be added as needed. If you need fu
 
 ## Installation
 
-* Requires ponyc 0.64.0 or later
+* Requires ponyc 0.65.0 or later
 * Install [corral](https://github.com/ponylang/corral)
 * `corral add github.com/ponylang/github_rest_api.git --version 0.5.0`
 * `corral fetch` to fetch your dependencies

--- a/github_rest_api/_test_json_converters.pony
+++ b/github_rest_api/_test_json_converters.pony
@@ -2012,9 +2012,9 @@ class \nodoc\ _TestJsonTypeStringAllArms is UnitTest
         .update("f64", F64(3.14))
         .update("bool", true)
         .update("null", None))
-    h.assert_eq[String](obj.string(),
+    h.assert_eq[String](obj.print(),
       req.JsonTypeString(nav("obj")))
-    h.assert_eq[String](arr.string(),
+    h.assert_eq[String](arr.print(),
       req.JsonTypeString(nav("arr")))
     h.assert_eq[String]("hello",
       req.JsonTypeString(nav("str")))

--- a/github_rest_api/gist.pony
+++ b/github_rest_api/gist.pony
@@ -221,7 +221,7 @@ primitive CreateGist
     match description
     | let d: String => obj = obj.update("description", d)
     end
-    let json = obj.string()
+    let json = obj.print()
 
     req.JsonRequester.post(creds, url, consume json, r)
     p
@@ -278,7 +278,7 @@ primitive UpdateGist
     match description
     | let d: String => obj = obj.update("description", d)
     end
-    let json = obj.string()
+    let json = obj.print()
 
     req.JsonRequester.patch(creds, url, consume json, r)
     p

--- a/github_rest_api/gist_comment.pony
+++ b/github_rest_api/gist_comment.pony
@@ -145,7 +145,7 @@ primitive CreateGistComment
       p,
       GistCommentJsonConverter)
 
-    let json = JsonObject.update("body", body).string()
+    let json = JsonObject.update("body", body).print()
     req.JsonRequester.post(creds, url, consume json, r)
     p
 
@@ -180,7 +180,7 @@ primitive UpdateGistComment
       p,
       GistCommentJsonConverter)
 
-    let json = JsonObject.update("body", body).string()
+    let json = JsonObject.update("body", body).print()
     req.JsonRequester.patch(creds, url, consume json, r)
     p
 

--- a/github_rest_api/issue_comment.pony
+++ b/github_rest_api/issue_comment.pony
@@ -58,7 +58,7 @@ primitive CreateIssueComment
       p,
       IssueCommentJsonConverter)
 
-    let json = JsonObject.update("body", comment).string()
+    let json = JsonObject.update("body", comment).print()
     req.JsonRequester.post(creds, url, consume json, r)
     p
 

--- a/github_rest_api/label.pony
+++ b/github_rest_api/label.pony
@@ -78,7 +78,7 @@ primitive CreateLabel
     match description
     | let d: String => obj = obj.update("description", d)
     end
-    let json = obj.string()
+    let json = obj.print()
     req.JsonRequester.post(creds, url, consume json, r)
     p
 

--- a/github_rest_api/release.pony
+++ b/github_rest_api/release.pony
@@ -129,7 +129,7 @@ primitive CreateRelease
       obj = obj.update("target_commitish", tc)
     end
     obj = obj.update("draft", draft).update("prerelease", prerelease)
-    let json = obj.string()
+    let json = obj.print()
     req.JsonRequester.post(creds, url, consume json, r)
     p
 

--- a/github_rest_api/request/json.pony
+++ b/github_rest_api/request/json.pony
@@ -7,8 +7,8 @@ primitive JsonTypeString
   """Convert a JsonNav's value to its JSON string representation for error messages."""
   fun apply(json: JsonNav): String =>
     match \exhaustive\ json.json()
-    | let o: JsonObject => o.string()
-    | let a: JsonArray => a.string()
+    | let o: JsonObject => o.print()
+    | let a: JsonArray => a.print()
     | let s: String => s
     | let i: I64 => i.string()
     | let f: F64 => f.string()


### PR DESCRIPTION
ponyc 0.65.0 drops `Stringable` from `JsonObject`/`JsonArray` and renames their serialization methods (`.string()` → `.print()`), which broke compilation against it. This renames the 11 affected call sites, bumps the README minimum ponyc version to 0.65.0, and adds a `Fixed` release note.

Since 0.65.0 is not yet released, CI (`pr.yml`, `generate-documentation.yml`, `release.yml`) moves to nightly ponyc. Switching back to release is tracked as a post-release task in ponylang/ponyc#5392. The `pr.yml` job id/name are intentionally left referencing "release" so branch-protection required-check names are unaffected; the switch-back restores accuracy.

Built and tested locally against ponyc `0.64.0-9282cbcc7` (the PR #5397 build): 89/89 unit tests pass, examples build.

**Parked for input** (from the lightweight code review — Low/pre-existing, not introduced by this change):
- `_test_json_converters.pony:2015-2018` — the `obj`/`arr` assertions compare `.print()` against `JsonTypeString(...)`, which also calls `.print()`, so they verify match-dispatch but not serialization output. Pre-existing (both sides were `.string()` on main). Worth tightening to literal-JSON assertions, or fine to leave?

Note: this library should not be *released* until ponyc 0.65.0 ships, since main now requires it.