### PR TITLE
Fix response never arriving after sending a large request

### DIFF
--- a/.release-notes/fix-silent-connection-after-large-request.md
+++ b/.release-notes/fix-silent-connection-after-large-request.md
@@ -1,0 +1,3 @@
+## Fix response never arriving after sending a large request
+
+After sending a large request, a connection could stop receiving the server's response — the response would never arrive and the request would hang indefinitely. No error was raised and the connection was not closed; it simply went quiet, even though the server had already replied. This most often showed up on connections that pushed a large request body, such as uploads. Responses now arrive as expected.

--- a/corral.json
+++ b/corral.json
@@ -10,7 +10,7 @@
     },
     {
       "locator": "github.com/ponylang/courier.git",
-      "version": "0.3.0"
+      "version": "0.3.1"
     },
     {
       "locator": "github.com/ponylang/uri.git",


### PR DESCRIPTION
Updates courier to 0.3.1, which fixes a connection that could stop receiving the server's response after a large request, leaving the request to hang.