### PR TITLE
Update courier to 0.4.0

### DIFF
--- a/.release-notes/next-release.md
+++ b/.release-notes/next-release.md
@@ -1,0 +1,7 @@
+## Fix connections closed mid-transfer by the idle timeout
+
+A request could be closed by its idle timeout while the response was still actively arriving. A large response draining slowly over a slow connection looked idle even though data was still moving, so it was closed mid-transfer. A connection is now closed by the idle timeout only when no data has moved in either direction for the timeout.
+
+## Drop support for Windows 10
+
+Building github_rest_api for Windows now requires ponyc 0.66.0 or later and Windows 11 or Windows Server 2022 or later. Windows 10 is no longer supported. Non-Windows platforms are unaffected.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,14 @@ All notable changes to this project will be documented in this file. This projec
 
 ### Fixed
 
+- Fix connections closed mid-transfer by the idle timeout ([PR #132](https://github.com/ponylang/github_rest_api/pull/132))
 
 ### Added
 
 
 ### Changed
+
+- Drop support for Windows 10 ([PR #132](https://github.com/ponylang/github_rest_api/pull/132))
 
 
 ## [0.6.0] - 2026-06-27

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Additional API surface and functionality will be added as needed. If you need fu
 
 ## Installation
 
-* Requires ponyc 0.65.0 or later
+* Requires ponyc 0.65.0 or later. On Windows, requires ponyc 0.66.0 or later.
 * Install [corral](https://github.com/ponylang/corral)
 * `corral add github.com/ponylang/github_rest_api.git --version 0.6.0`
 * `corral fetch` to fetch your dependencies

--- a/corral.json
+++ b/corral.json
@@ -10,7 +10,7 @@
     },
     {
       "locator": "github.com/ponylang/courier.git",
-      "version": "0.3.1"
+      "version": "0.4.0"
     },
     {
       "locator": "github.com/ponylang/uri.git",


### PR DESCRIPTION
Picks up courier's fix for responses being cut off mid-transfer by the idle timeout, and drops Windows 10 support — building github_rest_api for Windows now requires ponyc 0.66.0 and Windows 11 / Server 2022 or later.