### PR TITLE
Update courier to 0.5.0 and add ssl 4.0.0

### DIFF
--- a/.release-notes/next-release.md
+++ b/.release-notes/next-release.md
@@ -1,0 +1,31 @@
+## Fix a request hanging when its connection closed
+
+A request closes its connection when handling a redirect, when the response is complete, or on a parse error. That close could leave the connection issuing one more read on the closed socket. When many requests run at once, that read could block a scheduler thread and prevent the program from exiting.
+
+## Fix a connection stalling under sustained write backpressure
+
+Under sustained write backpressure with the server still sending, a connection could stall permanently: data stopped moving in both directions, and the connection stayed wedged until closed. This was most likely on a multi-threaded runtime.
+
+## Fix a hang when writing to a socket under load
+
+Under write load, sending on a connection could hang the program. This required the operating system to reuse a closed connection's file descriptor for a blocking socket elsewhere in the process — rare, but possible. The hang is fixed on Linux, FreeBSD, OpenBSD, and DragonFly. macOS and Windows are unchanged.
+
+## Fix TLS bugs that could misreport handshake failures, drop data, or close the wrong connection
+
+TLS connection handling had bugs that could cause handshake failures to be misreported, data to be silently dropped during encrypted writes, and one connection's TLS failure to close a different connection.
+
+## Fix a macOS bug where setting up a connection could close an unrelated file descriptor
+
+On macOS, setting up a connection could close one of its own file descriptors twice. The operating system can hand that descriptor number to something else in between, so the second close lands on an unrelated connection or file. Connecting to a host that resolves to more than one address is the likeliest way to hit it. The same cleanup also miscounted outstanding connection attempts, which could abandon a working attempt and report the connection as failed, or leave a connection asked to close gracefully never finishing. Linux and Windows were not affected.
+
+## Fix TLS connections not sending close_notify on graceful close
+
+Closing a TLS connection now sends a `close_notify` alert before the TCP shutdown. Without it, the server could not distinguish a clean close from a truncated stream.
+
+## Drop support for OpenSSL 0.9.x
+
+Building with `ssl=0.9.0` is no longer supported. OpenSSL 0.9.x has been end-of-life since 2016; use OpenSSL 1.1.x or 3.0.x.
+
+## Require ponyc 0.67.0 or later
+
+github_rest_api now requires ponyc 0.67.0 or later on every platform. The previous minimum was 0.66.0 on Windows and 0.64.0 on other platforms; 0.64.0 through 0.66.x are no longer supported.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ make config=debug ssl=3.0.x          # debug build
 make clean                           # clean build artifacts + corral deps
 ```
 
-`ssl=` is required on every build and test target, set to your installed TLS library: `3.0.x`, `1.1.x`, or `0.9.0`. `make` runs `corral fetch` before compiling.
+`ssl=` is required on every build and test target, set to your installed TLS library: `3.0.x` or `1.1.x`. `make` runs `corral fetch` before compiling.
 
 ## Architecture
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,20 @@ All notable changes to this project will be documented in this file. This projec
 
 ### Fixed
 
+- Fix a request hanging when its connection closed ([PR #137](https://github.com/ponylang/github_rest_api/pull/137))
+- Fix a connection stalling under sustained write backpressure ([PR #137](https://github.com/ponylang/github_rest_api/pull/137))
+- Fix a hang when writing to a socket under load ([PR #137](https://github.com/ponylang/github_rest_api/pull/137))
+- Fix TLS bugs that could misreport handshake failures, drop data, or close the wrong connection ([PR #137](https://github.com/ponylang/github_rest_api/pull/137))
+- Fix a macOS bug where setting up a connection could close an unrelated file descriptor ([PR #137](https://github.com/ponylang/github_rest_api/pull/137))
+- Fix TLS connections not sending close_notify on graceful close ([PR #137](https://github.com/ponylang/github_rest_api/pull/137))
 
 ### Added
 
 
 ### Changed
+
+- Drop support for OpenSSL 0.9.x ([PR #137](https://github.com/ponylang/github_rest_api/pull/137))
+- Require ponyc 0.67.0 or later ([PR #137](https://github.com/ponylang/github_rest_api/pull/137))
 
 
 ## [0.7.0] - 2026-06-30

--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,6 @@ ifeq (,$(filter $(MAKECMDGOALS),clean docs realclean TAGS))
     SSL = -Dopenssl_3.0.x
   else ifeq ($(ssl), 1.1.x)
     SSL = -Dopenssl_1.1.x
-  else ifeq ($(ssl), 0.9.0)
-    SSL = -Dopenssl_0.9.0
   else
     $(error Unknown SSL version "$(ssl)". Must set using 'ssl=FOO')
   endif

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Additional API surface and functionality will be added as needed. If you need fu
 
 ## Installation
 
-* Requires ponyc 0.65.0 or later. On Windows, requires ponyc 0.66.0 or later.
+* Requires ponyc 0.67.0 or later.
 * Install [corral](https://github.com/ponylang/corral)
 * `corral add github.com/ponylang/github_rest_api.git --version 0.7.0`
 * `corral fetch` to fetch your dependencies

--- a/corral.json
+++ b/corral.json
@@ -10,7 +10,11 @@
     },
     {
       "locator": "github.com/ponylang/courier.git",
-      "version": "0.4.0"
+      "version": "0.5.0"
+    },
+    {
+      "locator": "github.com/ponylang/ssl.git",
+      "version": "4.0.0"
     },
     {
       "locator": "github.com/ponylang/uri.git",

--- a/github_rest_api/_test_mock_http_server.pony
+++ b/github_rest_api/_test_mock_http_server.pony
@@ -103,10 +103,11 @@ actor \nodoc\ _MockHTTPConnection
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _buf.append(consume data)
     if _buf.contains("\r\n\r\n") then
       let request: String val = (_buf = String).clone()
       let response = _responder(request)
       _tcp_connection.send(response)
     end
+    lori.KeepReading


### PR DESCRIPTION
Picks up bug fixes in courier and lori (backpressure stalls, write hangs, TLS connection bugs, macOS FD double-close, missing close_notify). Adds ssl as a direct dependency since the project uses its types. Drops ssl=0.9.0 support (ssl 4.0.0 doesn't support OpenSSL 0.9.x). Minimum ponyc is now 0.67.0.
