### PR TITLE
Update courier to 0.6.0

### DIFF
--- a/corral.json
+++ b/corral.json
@@ -10,7 +10,7 @@
     },
     {
       "locator": "github.com/ponylang/courier.git",
-      "version": "0.5.0"
+      "version": "0.6.0"
     },
     {
       "locator": "github.com/ponylang/ssl.git",
@@ -18,7 +18,7 @@
     },
     {
       "locator": "github.com/ponylang/uri.git",
-      "version": "0.1.0"
+      "version": "0.3.0"
     }
   ],
   "info": {

--- a/github_rest_api/paginated_list.pony
+++ b/github_rest_api/paginated_list.pony
@@ -4,6 +4,7 @@ use lori = "lori"
 use "promises"
 use req = "request"
 use ssl = "ssl/net"
+use uri = "uri"
 
 interface tag LinkedResultReceiver
   """
@@ -159,18 +160,29 @@ actor LinkedJsonRequester is courier.HTTPClientConnectionActor
     _connect(url)
 
   fun ref _connect(url: String) =>
-    match courier.URL.parse(url)
-    | let parsed: courier.ParsedURL =>
-      _request_path = parsed.request_path()
-      let ctx = match _creds.ssl_ctx
-      | let c: ssl.SSLContext val => c
-      | None => req.SSLContextFactory()
+    match uri.ParseURI(url)
+    | let parsed: uri.URI val =>
+      match parsed.authority
+      | let auth: uri.URIAuthority =>
+        _request_path = parsed.path
+        match parsed.query
+        | let q: String => _request_path = _request_path + "?" + q
+        end
+        let port = match auth.port
+        | let p: U16 => p.string()
+        | None => "443"
+        end
+        let ctx = match _creds.ssl_ctx
+        | let c: ssl.SSLContext val => c
+        | None => req.SSLContextFactory()
+        end
+        let config = courier.ClientConnectionConfig
+        _http = courier.HTTPClientConnection.ssl(
+          _creds.auth, ctx, auth.host, port, this, config)
+      else
+        _fail("Unable to parse URL: " + url)
       end
-      let config = courier.ClientConnectionConfig
-      _http = courier.HTTPClientConnection.ssl(
-        _creds.auth, ctx, parsed.host, parsed.port,
-        this, config)
-    | let _: courier.URLParseError =>
+    | let _: uri.URIParseError val =>
       _fail("Unable to parse URL: " + url)
     end
 

--- a/github_rest_api/request/check_requester.pony
+++ b/github_rest_api/request/check_requester.pony
@@ -1,6 +1,7 @@
 use courier = "courier"
 use "promises"
 use ssl = "ssl/net"
+use uri = "uri"
 
 interface tag CheckResultReceiver
   """
@@ -55,18 +56,29 @@ actor CheckRequester is courier.HTTPClientConnectionActor
     _connect(url)
 
   fun ref _connect(url: String) =>
-    match courier.URL.parse(url)
-    | let parsed: courier.ParsedURL =>
-      _request_path = parsed.request_path()
-      let ctx = match _creds.ssl_ctx
-      | let c: ssl.SSLContext val => c
-      | None => SSLContextFactory()
+    match uri.ParseURI(url)
+    | let parsed: uri.URI val =>
+      match parsed.authority
+      | let auth: uri.URIAuthority =>
+        _request_path = parsed.path
+        match parsed.query
+        | let q: String => _request_path = _request_path + "?" + q
+        end
+        let port = match auth.port
+        | let p: U16 => p.string()
+        | None => "443"
+        end
+        let ctx = match _creds.ssl_ctx
+        | let c: ssl.SSLContext val => c
+        | None => SSLContextFactory()
+        end
+        let config = courier.ClientConnectionConfig
+        _http = courier.HTTPClientConnection.ssl(
+          _creds.auth, ctx, auth.host, port, this, config)
+      else
+        _fail("Unable to parse URL: " + url)
       end
-      let config = courier.ClientConnectionConfig
-      _http = courier.HTTPClientConnection.ssl(
-        _creds.auth, ctx, parsed.host, parsed.port,
-        this, config)
-    | let _: courier.URLParseError =>
+    | let _: uri.URIParseError val =>
       _fail("Unable to parse URL: " + url)
     end
 

--- a/github_rest_api/request/json_requester.pony
+++ b/github_rest_api/request/json_requester.pony
@@ -1,6 +1,7 @@
 use courier = "courier"
 use "json"
 use ssl = "ssl/net"
+use uri = "uri"
 
 interface tag JsonRequesterResultReceiver
   """
@@ -74,18 +75,29 @@ actor JsonRequester is courier.HTTPClientConnectionActor
     _connect(url)
 
   fun ref _connect(url: String) =>
-    match courier.URL.parse(url)
-    | let parsed: courier.ParsedURL =>
-      _request_path = parsed.request_path()
-      let ctx = match _creds.ssl_ctx
-      | let c: ssl.SSLContext val => c
-      | None => SSLContextFactory()
+    match uri.ParseURI(url)
+    | let parsed: uri.URI val =>
+      match parsed.authority
+      | let auth: uri.URIAuthority =>
+        _request_path = parsed.path
+        match parsed.query
+        | let q: String => _request_path = _request_path + "?" + q
+        end
+        let port = match auth.port
+        | let p: U16 => p.string()
+        | None => "443"
+        end
+        let ctx = match _creds.ssl_ctx
+        | let c: ssl.SSLContext val => c
+        | None => SSLContextFactory()
+        end
+        let config = courier.ClientConnectionConfig
+        _http = courier.HTTPClientConnection.ssl(
+          _creds.auth, ctx, auth.host, port, this, config)
+      else
+        _fail("Unable to parse URL: " + url)
       end
-      let config = courier.ClientConnectionConfig
-      _http = courier.HTTPClientConnection.ssl(
-        _creds.auth, ctx, parsed.host, parsed.port,
-        this, config)
-    | let _: courier.URLParseError =>
+    | let _: uri.URIParseError val =>
       _fail("Unable to parse URL: " + url)
     end
 

--- a/github_rest_api/request/no_content_requester.pony
+++ b/github_rest_api/request/no_content_requester.pony
@@ -1,6 +1,7 @@
 use courier = "courier"
 use "promises"
 use ssl = "ssl/net"
+use uri = "uri"
 
 interface tag DeleteResultReceiver
   """
@@ -74,18 +75,29 @@ actor NoContentRequester is courier.HTTPClientConnectionActor
     _connect(url)
 
   fun ref _connect(url: String) =>
-    match courier.URL.parse(url)
-    | let parsed: courier.ParsedURL =>
-      _request_path = parsed.request_path()
-      let ctx = match _creds.ssl_ctx
-      | let c: ssl.SSLContext val => c
-      | None => SSLContextFactory()
+    match uri.ParseURI(url)
+    | let parsed: uri.URI val =>
+      match parsed.authority
+      | let auth: uri.URIAuthority =>
+        _request_path = parsed.path
+        match parsed.query
+        | let q: String => _request_path = _request_path + "?" + q
+        end
+        let port = match auth.port
+        | let p: U16 => p.string()
+        | None => "443"
+        end
+        let ctx = match _creds.ssl_ctx
+        | let c: ssl.SSLContext val => c
+        | None => SSLContextFactory()
+        end
+        let config = courier.ClientConnectionConfig
+        _http = courier.HTTPClientConnection.ssl(
+          _creds.auth, ctx, auth.host, port, this, config)
+      else
+        _fail("Unable to parse URL: " + url)
       end
-      let config = courier.ClientConnectionConfig
-      _http = courier.HTTPClientConnection.ssl(
-        _creds.auth, ctx, parsed.host, parsed.port,
-        this, config)
-    | let _: courier.URLParseError =>
+    | let _: uri.URIParseError val =>
       _fail("Unable to parse URL: " + url)
     end
 


### PR DESCRIPTION
Courier 0.6.0 removed its built-in URL parser in favor of ponylang/uri. Switch the four request actors from courier's URL/ParsedURL/URLParseError to uri's ParseURI/URI/URIParseError.