### PR TITLE
Update to work with Pony 0.69.1

### DIFF
--- a/.release-notes/update-for-pony-0.69.1.md
+++ b/.release-notes/update-for-pony-0.69.1.md
@@ -1,0 +1,3 @@
+## Update to work with Pony 0.69.1
+
+Pony 0.69.1 is the new minimum required version.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Additional API surface and functionality will be added as needed. If you need fu
 
 ## Installation
 
-* Requires ponyc 0.67.0 or later.
+* Requires ponyc 0.69.1 or later.
 * Install [corral](https://github.com/ponylang/corral)
 * `corral add github.com/ponylang/github_rest_api.git --version 0.8.0`
 * `corral fetch` to fetch your dependencies

--- a/corral.json
+++ b/corral.json
@@ -10,7 +10,7 @@
     },
     {
       "locator": "github.com/ponylang/courier.git",
-      "version": "0.6.0"
+      "version": "0.7.0"
     },
     {
       "locator": "github.com/ponylang/ssl.git",

--- a/github_rest_api/_test_json_converters.pony
+++ b/github_rest_api/_test_json_converters.pony
@@ -16,10 +16,10 @@ class \nodoc\ _TestGitPersonJsonConverterPreservesValues is UnitTest
         let b: String val = base.clone()
         let name_val: String val = "name_" + b
         let email_val: String val = "email_" + b
-        let obj = JsonObject
+        let obj = JSONObject
           .update("name", name_val)
           .update("email", email_val)
-        let json = JsonNav(obj)
+        let json = JSONNav(obj)
         try
           let person = GitPersonJsonConverter(json, creds)?
           h.assert_eq[String](name_val, person.name)
@@ -40,10 +40,10 @@ class \nodoc\ _TestGitPersonJsonConverterMissingField is UnitTest
         let auth = lori.TCPConnectAuth(h.env.root)
         let creds = req.Credentials(auth)
         let b: String val = base.clone()
-        var obj = JsonObject
+        var obj = JSONObject
         if skip_idx != 0 then obj = obj.update("name", "name_" + b) end
         if skip_idx != 1 then obj = obj.update("email", "email_" + b) end
-        let json = JsonNav(obj)
+        let json = JSONNav(obj)
         try
           GitPersonJsonConverter(json, creds)?
           h.fail("converter should have raised for missing field at index "
@@ -66,13 +66,13 @@ class \nodoc\ _TestLicenseJsonConverterPreservesValues is UnitTest
         let key_val: String val = "key_" + b
         let spdx_id_val: String val = "spdx_id_" + b
         let url_val: String val = "url_" + b
-        let obj = JsonObject
+        let obj = JSONObject
           .update("node_id", node_id_val)
           .update("name", name_val)
           .update("key", key_val)
           .update("spdx_id", spdx_id_val)
           .update("url", url_val)
-        let json = JsonNav(obj)
+        let json = JSONNav(obj)
         try
           let license = LicenseJsonConverter(json, creds)?
           h.assert_eq[String](node_id_val, license.node_id)
@@ -96,13 +96,13 @@ class \nodoc\ _TestLicenseJsonConverterMissingField is UnitTest
         let auth = lori.TCPConnectAuth(h.env.root)
         let creds = req.Credentials(auth)
         let b: String val = base.clone()
-        var obj = JsonObject
+        var obj = JSONObject
         if skip_idx != 0 then obj = obj.update("node_id", "node_id_" + b) end
         if skip_idx != 1 then obj = obj.update("name", "name_" + b) end
         if skip_idx != 2 then obj = obj.update("key", "key_" + b) end
         if skip_idx != 3 then obj = obj.update("spdx_id", "spdx_id_" + b) end
         if skip_idx != 4 then obj = obj.update("url", "url_" + b) end
-        let json = JsonNav(obj)
+        let json = JSONNav(obj)
         try
           LicenseJsonConverter(json, creds)?
           h.fail("converter should have raised for missing field at index "
@@ -123,11 +123,11 @@ class \nodoc\ _TestCommitFileJsonConverterPreservesValues is UnitTest
         let sha_val: String val = "sha_" + b
         let status_val: String val = "status_" + b
         let filename_val: String val = "filename_" + b
-        let obj = JsonObject
+        let obj = JSONObject
           .update("sha", sha_val)
           .update("status", status_val)
           .update("filename", filename_val)
-        let json = JsonNav(obj)
+        let json = JSONNav(obj)
         try
           let file = CommitFileJsonConverter(json, creds)?
           h.assert_eq[String](sha_val, file.sha)
@@ -149,13 +149,13 @@ class \nodoc\ _TestCommitFileJsonConverterMissingField is UnitTest
         let auth = lori.TCPConnectAuth(h.env.root)
         let creds = req.Credentials(auth)
         let b: String val = base.clone()
-        var obj = JsonObject
+        var obj = JSONObject
         if skip_idx != 0 then obj = obj.update("sha", "sha_" + b) end
         if skip_idx != 1 then obj = obj.update("status", "status_" + b) end
         if skip_idx != 2 then
           obj = obj.update("filename", "filename_" + b)
         end
-        let json = JsonNav(obj)
+        let json = JSONNav(obj)
         try
           CommitFileJsonConverter(json, creds)?
           h.fail("converter should have raised for missing field at index "
@@ -175,11 +175,11 @@ class \nodoc\ _TestGistChangeStatusJsonConverterPreservesValues is UnitTest
       {(additions, deletions, total, h) =>
         let auth = lori.TCPConnectAuth(h.env.root)
         let creds = req.Credentials(auth)
-        let obj = JsonObject
+        let obj = JSONObject
           .update("additions", additions)
           .update("deletions", deletions)
           .update("total", total)
-        let json = JsonNav(obj)
+        let json = JSONNav(obj)
         try
           let status = GistChangeStatusJsonConverter(json, creds)?
           h.assert_eq[I64](additions, status.additions)
@@ -201,11 +201,11 @@ class \nodoc\ _TestGistChangeStatusJsonConverterMissingField is UnitTest
       {(value, skip_idx, h) =>
         let auth = lori.TCPConnectAuth(h.env.root)
         let creds = req.Credentials(auth)
-        var obj = JsonObject
+        var obj = JSONObject
         if skip_idx != 0 then obj = obj.update("additions", value) end
         if skip_idx != 1 then obj = obj.update("deletions", value) end
         if skip_idx != 2 then obj = obj.update("total", value) end
-        let json = JsonNav(obj)
+        let json = JSONNav(obj)
         try
           GistChangeStatusJsonConverter(json, creds)?
           h.fail("converter should have raised for missing field at index "
@@ -217,8 +217,8 @@ primitive \nodoc\ _TestUserJson
   """
   Builds a valid User JSON object for testing converters that nest a User.
   """
-  fun apply(b: String val): JsonObject =>
-    JsonObject
+  fun apply(b: String val): JSONObject =>
+    JSONObject
       .update("login", "login_" + b)
       .update("id", I64(1))
       .update("node_id", "unode_" + b)
@@ -243,8 +243,8 @@ primitive \nodoc\ _TestGitPersonJson
   Builds a valid GitPerson JSON object for testing converters that nest a
   GitPerson.
   """
-  fun apply(b: String val): JsonObject =>
-    JsonObject
+  fun apply(b: String val): JSONObject =>
+    JSONObject
       .update("name", "name_" + b)
       .update("email", "email_" + b)
 
@@ -253,8 +253,8 @@ primitive \nodoc\ _TestCommitFileJson
   Builds a valid CommitFile JSON object for testing converters that nest a
   CommitFile.
   """
-  fun apply(b: String val): JsonObject =>
-    JsonObject
+  fun apply(b: String val): JSONObject =>
+    JSONObject
       .update("sha", "sha_" + b)
       .update("status", "status_" + b)
       .update("filename", "filename_" + b)
@@ -264,8 +264,8 @@ primitive \nodoc\ _TestGitCommitJson
   Builds a valid GitCommit JSON object for testing converters that nest a
   GitCommit.
   """
-  fun apply(b: String val): JsonObject =>
-    JsonObject
+  fun apply(b: String val): JSONObject =>
+    JSONObject
       .update("author", _TestGitPersonJson(b))
       .update("committer", _TestGitPersonJson(b))
       .update("message", "message_" + b)
@@ -275,8 +275,8 @@ primitive \nodoc\ _TestLabelJson
   """
   Builds a valid Label JSON object for testing converters that nest a Label.
   """
-  fun apply(b: String val): JsonObject =>
-    JsonObject
+  fun apply(b: String val): JSONObject =>
+    JSONObject
       .update("id", I64(42))
       .update("node_id", "lnid_" + b)
       .update("url", "lurl_" + b)
@@ -290,8 +290,8 @@ primitive \nodoc\ _TestIssuePullRequestJson
   Builds a valid IssuePullRequest JSON object for testing converters that
   nest an IssuePullRequest.
   """
-  fun apply(b: String val): JsonObject =>
-    JsonObject
+  fun apply(b: String val): JSONObject =>
+    JSONObject
       .update("url", "prurl_" + b)
       .update("html_url", "prhtml_" + b)
       .update("diff_url", "prdiff_" + b)
@@ -315,7 +315,7 @@ class \nodoc\ _TestLabelJsonConverterPreservesValues is UnitTest
         let name_val: String val = "name_" + b
         let color_val: String val = "color_" + b
         let desc_val: String val = "desc_" + b
-        var obj = JsonObject
+        var obj = JSONObject
           .update("id", id_val)
           .update("node_id", node_id_val)
           .update("url", url_val)
@@ -327,7 +327,7 @@ class \nodoc\ _TestLabelJsonConverterPreservesValues is UnitTest
         else
           obj = obj.update("description", desc_val)
         end
-        let json = JsonNav(obj)
+        let json = JSONNav(obj)
         try
           let lbl = LabelJsonConverter(json, creds)?
           h.assert_eq[I64](id_val, lbl.id)
@@ -366,7 +366,7 @@ class \nodoc\ _TestLabelJsonConverterMissingField is UnitTest
         let auth = lori.TCPConnectAuth(h.env.root)
         let creds = req.Credentials(auth)
         let b: String val = base.clone()
-        var obj = JsonObject
+        var obj = JSONObject
         if skip_idx != 0 then obj = obj.update("id", I64(42)) end
         if skip_idx != 1 then
           obj = obj.update("node_id", "nid_" + b)
@@ -384,7 +384,7 @@ class \nodoc\ _TestLabelJsonConverterMissingField is UnitTest
         if skip_idx != 6 then
           obj = obj.update("description", "desc_" + b)
         end
-        let json = JsonNav(obj)
+        let json = JSONNav(obj)
         try
           LabelJsonConverter(json, creds)?
           h.fail(
@@ -410,7 +410,7 @@ class \nodoc\ _TestIssuePRJsonConverterPreservesValues is UnitTest
         let diff_url_val: String val = "diff_" + b
         let patch_url_val: String val = "patch_" + b
         let merged_val: String val = "merged_" + b
-        var obj = JsonObject
+        var obj = JSONObject
           .update("url", url_val)
           .update("html_url", html_url_val)
           .update("diff_url", diff_url_val)
@@ -420,7 +420,7 @@ class \nodoc\ _TestIssuePRJsonConverterPreservesValues is UnitTest
         else
           obj = obj.update("merged_at", merged_val)
         end
-        let json = JsonNav(obj)
+        let json = JSONNav(obj)
         try
           let ipr =
             IssuePullRequestJsonConverter(json, creds)?
@@ -459,7 +459,7 @@ class \nodoc\ _TestIssuePRJsonConverterMissingField is UnitTest
         let auth = lori.TCPConnectAuth(h.env.root)
         let creds = req.Credentials(auth)
         let b: String val = base.clone()
-        var obj = JsonObject
+        var obj = JSONObject
         if skip_idx != 0 then
           obj = obj.update("url", "url_" + b)
         end
@@ -475,7 +475,7 @@ class \nodoc\ _TestIssuePRJsonConverterMissingField is UnitTest
         if skip_idx != 4 then
           obj = obj.update("merged_at", "m_" + b)
         end
-        let json = JsonNav(obj)
+        let json = JSONNav(obj)
         try
           IssuePullRequestJsonConverter(json, creds)?
           h.fail(
@@ -509,7 +509,7 @@ class \nodoc\ _TestAssetJsonConverterPreservesValues is UnitTest
         let url_val: String val = "url_" + b
         let bd_val: String val = "bd_" + b
         let uploader_obj = _TestUserJson(b)
-        var obj = JsonObject
+        var obj = JSONObject
           .update("id", id_val)
           .update("node_id", node_id_val)
           .update("name", name_val)
@@ -527,7 +527,7 @@ class \nodoc\ _TestAssetJsonConverterPreservesValues is UnitTest
         else
           obj = obj.update("label", label_val)
         end
-        let json = JsonNav(obj)
+        let json = JSONNav(obj)
         try
           let asset = AssetJsonConverter(json, creds)?
           h.assert_eq[I64](id_val, asset.id)
@@ -577,7 +577,7 @@ class \nodoc\ _TestAssetJsonConverterMissingField is UnitTest
         let creds = req.Credentials(auth)
         let b: String val = base.clone()
         let uploader_obj = _TestUserJson(b)
-        var obj = JsonObject
+        var obj = JSONObject
         if skip_idx != 0 then
           obj = obj.update("id", I64(42))
         end
@@ -618,7 +618,7 @@ class \nodoc\ _TestAssetJsonConverterMissingField is UnitTest
           obj = obj.update(
             "browser_download_url", "bd_" + b)
         end
-        let json = JsonNav(obj)
+        let json = JSONNav(obj)
         try
           AssetJsonConverter(json, creds)?
           h.fail(
@@ -646,7 +646,7 @@ class \nodoc\ _TestGistFileJsonConverterPreservesValues is UnitTest
         let size_val: I64 = 256
         let content_val: String val = "content_" + b
         let encoding_val: String val = "utf-8"
-        var obj = JsonObject
+        var obj = JSONObject
           .update("filename", fn_val)
           .update("type", ct_val)
           .update("raw_url", raw_val)
@@ -659,7 +659,7 @@ class \nodoc\ _TestGistFileJsonConverterPreservesValues is UnitTest
         else
           obj = obj.update("language", lang_val)
         end
-        let json = JsonNav(obj)
+        let json = JSONNav(obj)
         try
           let gf = GistFileJsonConverter(json, creds)?
           h.assert_eq[String](fn_val, gf.filename)
@@ -715,7 +715,7 @@ class \nodoc\ _TestGistFileJsonConverterMissingField is UnitTest
         let auth = lori.TCPConnectAuth(h.env.root)
         let creds = req.Credentials(auth)
         let b: String val = base.clone()
-        var obj = JsonObject
+        var obj = JSONObject
         if skip_idx != 0 then
           obj = obj.update("filename", "fn_" + b)
         end
@@ -731,7 +731,7 @@ class \nodoc\ _TestGistFileJsonConverterMissingField is UnitTest
         if skip_idx != 4 then
           obj = obj.update("size", I64(100))
         end
-        let json = JsonNav(obj)
+        let json = JSONNav(obj)
         try
           GistFileJsonConverter(json, creds)?
           h.fail(
@@ -751,13 +751,13 @@ class \nodoc\ _TestGistFileJsonConverterAbsentOptionalFields is UnitTest
         let auth = lori.TCPConnectAuth(h.env.root)
         let creds = req.Credentials(auth)
         let b: String val = base.clone()
-        let obj = JsonObject
+        let obj = JSONObject
           .update("filename", "fn_" + b)
           .update("type", "ct_" + b)
           .update("language", "lang_" + b)
           .update("raw_url", "raw_" + b)
           .update("size", I64(100))
-        let json = JsonNav(obj)
+        let json = JSONNav(obj)
         try
           let gf = GistFileJsonConverter(json, creds)?
           h.assert_eq[String]("fn_" + b, gf.filename)
@@ -796,12 +796,12 @@ class \nodoc\ _TestGitCommitJsonConverterPreservesValues is UnitTest
         let b: String val = base.clone()
         let message_val: String val = "message_" + b
         let url_val: String val = "gcurl_" + b
-        let obj = JsonObject
+        let obj = JSONObject
           .update("author", _TestGitPersonJson(b))
           .update("committer", _TestGitPersonJson(b))
           .update("message", message_val)
           .update("url", url_val)
-        let json = JsonNav(obj)
+        let json = JSONNav(obj)
         try
           let gc = GitCommitJsonConverter(json, creds)?
           h.assert_eq[String]("name_" + b, gc.author.name)
@@ -830,7 +830,7 @@ class \nodoc\ _TestGitCommitJsonConverterMissingField is UnitTest
         let auth = lori.TCPConnectAuth(h.env.root)
         let creds = req.Credentials(auth)
         let b: String val = base.clone()
-        var obj = JsonObject
+        var obj = JSONObject
         if skip_idx != 0 then
           obj = obj.update("author",
             _TestGitPersonJson(b))
@@ -845,7 +845,7 @@ class \nodoc\ _TestGitCommitJsonConverterMissingField is UnitTest
         if skip_idx != 3 then
           obj = obj.update("url", "gcurl_" + b)
         end
-        let json = JsonNav(obj)
+        let json = JSONNav(obj)
         try
           GitCommitJsonConverter(json, creds)?
           h.fail(
@@ -869,15 +869,15 @@ class \nodoc\ _TestCommitJsonConverterPreservesValues is UnitTest
         let url_val: String val = "url_" + b
         let html_url_val: String val = "html_" + b
         let comments_url_val: String val = "curl_" + b
-        let obj = JsonObject
+        let obj = JSONObject
           .update("sha", sha_val)
           .update("files",
-            JsonArray.push(_TestCommitFileJson(b)))
+            JSONArray.push(_TestCommitFileJson(b)))
           .update("commit", _TestGitCommitJson(b))
           .update("url", url_val)
           .update("html_url", html_url_val)
           .update("comments_url", comments_url_val)
-        let json = JsonNav(obj)
+        let json = JSONNav(obj)
         try
           let c = CommitJsonConverter(json, creds)?
           h.assert_eq[String](sha_val, c.sha)
@@ -923,13 +923,13 @@ class \nodoc\ _TestCommitJsonConverterMissingField is UnitTest
         let auth = lori.TCPConnectAuth(h.env.root)
         let creds = req.Credentials(auth)
         let b: String val = base.clone()
-        var obj = JsonObject
+        var obj = JSONObject
         if skip_idx != 0 then
           obj = obj.update("sha", "sha_" + b)
         end
         if skip_idx != 1 then
           obj = obj.update("files",
-            JsonArray.push(_TestCommitFileJson(b)))
+            JSONArray.push(_TestCommitFileJson(b)))
         end
         if skip_idx != 2 then
           obj = obj.update("commit",
@@ -945,7 +945,7 @@ class \nodoc\ _TestCommitJsonConverterMissingField is UnitTest
           obj = obj.update("comments_url",
             "curl_" + b)
         end
-        let json = JsonNav(obj)
+        let json = JSONNav(obj)
         try
           CommitJsonConverter(json, creds)?
           h.fail(
@@ -977,7 +977,7 @@ class \nodoc\ _TestIssueJsonConverterPreservesValues is UnitTest
         let title_val: String val = "title_" + b
         let state_val: String val = "state_" + b
         let body_val: String val = "body_" + b
-        var obj = JsonObject
+        var obj = JSONObject
           .update("url", url_val)
           .update("repository_url", repo_url_val)
           .update("labels_url", labels_url_val)
@@ -988,7 +988,7 @@ class \nodoc\ _TestIssueJsonConverterPreservesValues is UnitTest
           .update("title", title_val)
           .update("user", _TestUserJson(b))
           .update("labels",
-            JsonArray.push(_TestLabelJson(b)))
+            JSONArray.push(_TestLabelJson(b)))
           .update("pull_request",
             _TestIssuePullRequestJson(b))
         if state_is_null then
@@ -1001,7 +1001,7 @@ class \nodoc\ _TestIssueJsonConverterPreservesValues is UnitTest
         else
           obj = obj.update("body", body_val)
         end
-        let json = JsonNav(obj)
+        let json = JSONNav(obj)
         try
           let issue =
             IssueJsonConverter(json, creds)?
@@ -1076,8 +1076,8 @@ primitive \nodoc\ _TestLicenseJson
   Builds a valid License JSON object for testing converters that
   nest a License.
   """
-  fun apply(b: String val): JsonObject =>
-    JsonObject
+  fun apply(b: String val): JSONObject =>
+    JSONObject
       .update("node_id", "licnid_" + b)
       .update("name", "licname_" + b)
       .update("key", "lickey_" + b)
@@ -1090,8 +1090,8 @@ primitive \nodoc\ _TestGistFileJson
   converters that nest a GistFile. Includes all optional fields
   (content, encoding, truncated).
   """
-  fun apply(b: String val): JsonObject =>
-    JsonObject
+  fun apply(b: String val): JSONObject =>
+    JSONObject
       .update("filename", "gfn_" + b)
       .update("type", "gftype_" + b)
       .update("language", "gflang_" + b)
@@ -1107,8 +1107,8 @@ primitive \nodoc\ _TestRepositoryJson
   RepositoryJsonConverter. Includes all required and optional
   fields with non-null values.
   """
-  fun apply(b: String val): JsonObject =>
-    JsonObject
+  fun apply(b: String val): JSONObject =>
+    JSONObject
       .update("id", I64(1))
       .update("node_id", "rnid_" + b)
       .update("name", "rname_" + b)
@@ -1191,8 +1191,8 @@ primitive \nodoc\ _TestGistJson
   default) so preserves-values can verify the explicit value and
   absent-optional can verify the default.
   """
-  fun apply(b: String val): JsonObject =>
-    JsonObject
+  fun apply(b: String val): JSONObject =>
+    JSONObject
       .update("id", "gid_" + b)
       .update("node_id", "gnid_" + b)
       .update("description", "gdesc_" + b)
@@ -1200,7 +1200,7 @@ primitive \nodoc\ _TestGistJson
       .update("owner", _TestUserJson(b))
       .update("user", _TestUserJson(b))
       .update("files",
-        JsonObject.update(
+        JSONObject.update(
           "file1_" + b, _TestGistFileJson(b)))
       .update("comments", I64(5))
       .update("comments_enabled", false)
@@ -1227,7 +1227,7 @@ class \nodoc\ _TestIssueJsonConverterMissingField is UnitTest
         let auth = lori.TCPConnectAuth(h.env.root)
         let creds = req.Credentials(auth)
         let b: String val = base.clone()
-        var obj = JsonObject
+        var obj = JSONObject
         if skip_idx != 0 then
           obj = obj.update("url", "url_" + b)
         end
@@ -1267,9 +1267,9 @@ class \nodoc\ _TestIssueJsonConverterMissingField is UnitTest
         end
         if skip_idx != 11 then
           obj = obj.update("labels",
-            JsonArray.push(_TestLabelJson(b)))
+            JSONArray.push(_TestLabelJson(b)))
         end
-        let json = JsonNav(obj)
+        let json = JSONNav(obj)
         try
           IssueJsonConverter(json, creds)?
           h.fail(
@@ -1289,7 +1289,7 @@ class \nodoc\ _TestIssueJsonConverterAbsentPullRequest is UnitTest
         let auth = lori.TCPConnectAuth(h.env.root)
         let creds = req.Credentials(auth)
         let b: String val = base.clone()
-        let obj = JsonObject
+        let obj = JSONObject
           .update("url", "url_" + b)
           .update("repository_url", "rurl_" + b)
           .update("labels_url", "lsurl_" + b)
@@ -1302,8 +1302,8 @@ class \nodoc\ _TestIssueJsonConverterAbsentPullRequest is UnitTest
           .update("state", "open")
           .update("body", "body_" + b)
           .update("labels",
-            JsonArray.push(_TestLabelJson(b)))
-        let json = JsonNav(obj)
+            JSONArray.push(_TestLabelJson(b)))
+        let json = JSONNav(obj)
         try
           let issue =
             IssueJsonConverter(json, creds)?
@@ -1344,7 +1344,7 @@ class \nodoc\ _TestRepoJsonConverterPreservesValues
         if (mask and 8) != 0 then
           obj = obj.update("mirror_url", None)
         end
-        let json = JsonNav(obj)
+        let json = JSONNav(obj)
         try
           let repo =
             RepositoryJsonConverter(json, creds)?
@@ -1662,7 +1662,7 @@ class \nodoc\ _TestRepoJsonConverterMissingField
         try
           let obj = _TestRepositoryJson(b)
             .remove(required(skip_idx)?)
-          let json = JsonNav(obj)
+          let json = JSONNav(obj)
           RepositoryJsonConverter(json, creds)?
           h.fail(
             "converter should have raised for "
@@ -1690,7 +1690,7 @@ class \nodoc\ _TestRepoJsonConverterAbsentOptionalFields
           .remove("license")
           .remove("network_count")
           .remove("subscribers_count")
-        let json = JsonNav(obj)
+        let json = JSONNav(obj)
         try
           let repo =
             RepositoryJsonConverter(json, creds)?
@@ -1747,7 +1747,7 @@ class \nodoc\ _TestGistJsonConverterPreservesValues
         if desc_is_null then
           obj = obj.update("description", None)
         end
-        let json = JsonNav(obj)
+        let json = JSONNav(obj)
         try
           let gist =
             GistJsonConverter(json, creds)?
@@ -1868,7 +1868,7 @@ class \nodoc\ _TestGistJsonConverterMissingField
         try
           let obj = _TestGistJson(b)
             .remove(required(skip_idx)?)
-          let json = JsonNav(obj)
+          let json = JSONNav(obj)
           GistJsonConverter(json, creds)?
           h.fail(
             "converter should have raised for "
@@ -1895,7 +1895,7 @@ class \nodoc\ _TestGistJsonConverterAbsentOptionalFields
           .remove("owner")
           .remove("user")
           .remove("comments_enabled")
-        let json = JsonNav(obj)
+        let json = JSONNav(obj)
         try
           let gist =
             GistJsonConverter(json, creds)?
@@ -1934,10 +1934,10 @@ class \nodoc\ _TestStringOrNoneReturnsString
       end, h)(
       {(base, h) =>
         let b: String val = base.clone()
-        let obj = JsonObject.update("key", b)
-        let json = JsonNav(obj)
+        let obj = JSONObject.update("key", b)
+        let json = JSONNav(obj)
         try
-          match JsonNavUtil.string_or_none(
+          match JSONNavUtil.string_or_none(
             json("key"))?
           | let s: String =>
             h.assert_eq[String](b, s)
@@ -1957,9 +1957,9 @@ class \nodoc\ _TestStringOrNoneReturnsNone
     "string-or-none/returns-none"
 
   fun ref apply(h: TestHelper) ? =>
-    let obj = JsonObject.update("key", None)
-    let json = JsonNav(obj)
-    match JsonNavUtil.string_or_none(
+    let obj = JSONObject.update("key", None)
+    let json = JSONNav(obj)
+    match JSONNavUtil.string_or_none(
       json("key"))?
     | None => None
     | let _: String =>
@@ -1977,10 +1977,10 @@ class \nodoc\ _TestStringOrNoneRaisesOnInvalid
       recover val Generators.i64() end, h)(
       {(value, h) =>
         let obj =
-          JsonObject.update("key", value)
-        let json = JsonNav(obj)
+          JSONObject.update("key", value)
+        let json = JSONNav(obj)
         try
-          JsonNavUtil.string_or_none(
+          JSONNavUtil.string_or_none(
             json("key"))?
           h.fail(
             "should raise for I64 value "
@@ -1988,10 +1988,10 @@ class \nodoc\ _TestStringOrNoneRaisesOnInvalid
         end
       })?
     // Missing key should also raise
-    let empty = JsonObject
-    let json = JsonNav(empty)
+    let empty = JSONObject
+    let json = JSONNav(empty)
     try
-      JsonNavUtil.string_or_none(
+      JSONNavUtil.string_or_none(
         json("missing"))?
       h.fail("should raise for missing key")
     end
@@ -2001,10 +2001,10 @@ class \nodoc\ _TestJsonTypeStringAllArms is UnitTest
     "json-type-string/all-arms"
 
   fun ref apply(h: TestHelper) =>
-    let obj = JsonObject.update("a", "b")
-    let arr = JsonArray.push("x")
-    let nav = JsonNav(
-      JsonObject
+    let obj = JSONObject.update("a", "b")
+    let arr = JSONArray.push("x")
+    let nav = JSONNav(
+      JSONObject
         .update("obj", obj)
         .update("arr", arr)
         .update("str", "hello")
@@ -2013,21 +2013,21 @@ class \nodoc\ _TestJsonTypeStringAllArms is UnitTest
         .update("bool", true)
         .update("null", None))
     h.assert_eq[String](obj.print(),
-      req.JsonTypeString(nav("obj")))
+      req.JSONTypeString(nav("obj")))
     h.assert_eq[String](arr.print(),
-      req.JsonTypeString(nav("arr")))
+      req.JSONTypeString(nav("arr")))
     h.assert_eq[String]("hello",
-      req.JsonTypeString(nav("str")))
+      req.JSONTypeString(nav("str")))
     h.assert_eq[String](I64(42).string(),
-      req.JsonTypeString(nav("i64")))
+      req.JSONTypeString(nav("i64")))
     h.assert_eq[String](F64(3.14).string(),
-      req.JsonTypeString(nav("f64")))
+      req.JSONTypeString(nav("f64")))
     h.assert_eq[String]("true",
-      req.JsonTypeString(nav("bool")))
+      req.JSONTypeString(nav("bool")))
     h.assert_eq[String]("null",
-      req.JsonTypeString(nav("null")))
-    h.assert_eq[String]("JsonNotFound",
-      req.JsonTypeString(nav("missing")))
+      req.JSONTypeString(nav("null")))
+    h.assert_eq[String]("JSONNotFound",
+      req.JSONTypeString(nav("missing")))
 
 class \nodoc\ _TestJsonTypeStringI64Property
   is UnitTest
@@ -2039,8 +2039,8 @@ class \nodoc\ _TestJsonTypeStringI64Property
       recover val Generators.i64() end, h)(
       {(value, h) =>
         let obj =
-          JsonObject.update("k", value)
-        let json = JsonNav(obj)
+          JSONObject.update("k", value)
+        let json = JSONNav(obj)
         h.assert_eq[String](value.string(),
-          req.JsonTypeString(json("k")))
+          req.JSONTypeString(json("k")))
       })?

--- a/github_rest_api/_test_mock_http_server.pony
+++ b/github_rest_api/_test_mock_http_server.pony
@@ -103,6 +103,9 @@ actor \nodoc\ _MockHTTPConnection
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+    None
+
   fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _buf.append(consume data)
     if _buf.contains("\r\n\r\n") then

--- a/github_rest_api/_test_request_actors.pony
+++ b/github_rest_api/_test_request_actors.pony
@@ -6,7 +6,7 @@ use ssl = "ssl/net"
 
 // --- Test receiver actors ---
 
-actor \nodoc\ _TestJsonSuccessReceiver is req.JsonRequesterResultReceiver
+actor \nodoc\ _TestJsonSuccessReceiver is req.JSONRequesterResultReceiver
   let _h: TestHelper
   let _expected_key: String
   let _expected_value: String
@@ -19,7 +19,7 @@ actor \nodoc\ _TestJsonSuccessReceiver is req.JsonRequesterResultReceiver
     _expected_key = expected_key
     _expected_value = expected_value
 
-  be success(json: JsonNav) =>
+  be success(json: JSONNav) =>
     try
       let actual = json(_expected_key).as_string()?
       _h.assert_eq[String](_expected_value, actual)
@@ -35,7 +35,7 @@ actor \nodoc\ _TestJsonSuccessReceiver is req.JsonRequesterResultReceiver
         + " body=" + response_body + " msg=" + message)
     _h.complete(false)
 
-actor \nodoc\ _TestJsonFailureReceiver is req.JsonRequesterResultReceiver
+actor \nodoc\ _TestJsonFailureReceiver is req.JSONRequesterResultReceiver
   let _h: TestHelper
   let _expected_status: U16
   let _expected_body: String
@@ -51,7 +51,7 @@ actor \nodoc\ _TestJsonFailureReceiver is req.JsonRequesterResultReceiver
     _expected_body = expected_body
     _expected_message = expected_message
 
-  be success(json: JsonNav) =>
+  be success(json: JSONNav) =>
     _h.fail("Expected failure, got success")
     _h.complete(false)
 
@@ -155,7 +155,7 @@ actor \nodoc\ _TestLinkedSuccessReceiver is LinkedResultReceiver
     _expected_value = expected_value
     _expected_link = expected_link
 
-  be success(json: JsonNav, link_header: String) =>
+  be success(json: JSONNav, link_header: String) =>
     try
       let actual = json(_expected_key).as_string()?
       _h.assert_eq[String](_expected_value, actual)
@@ -185,7 +185,7 @@ actor \nodoc\ _TestLinkedFailureReceiver is LinkedResultReceiver
     _expected_status = expected_status
     _expected_body = expected_body
 
-  be success(json: JsonNav, link_header: String) =>
+  be success(json: JSONNav, link_header: String) =>
     _h.fail("Expected failure, got success")
     _h.complete(false)
 
@@ -218,7 +218,7 @@ class \nodoc\ _TestJsonRequesterGetSuccess is UnitTest
       } val
     let listener = _MockHTTPListener(h, port, sslctx, responder,
       {()(creds, url, receiver) =>
-        req.JsonRequester.get(creds, url, receiver)
+        req.JSONRequester.get(creds, url, receiver)
       } val)
     h.dispose_when_done(listener)
 
@@ -244,7 +244,7 @@ class \nodoc\ _TestJsonRequesterGetFailure is UnitTest
       } val
     let listener = _MockHTTPListener(h, port, sslctx, responder,
       {()(creds, url, receiver) =>
-        req.JsonRequester.get(creds, url, receiver)
+        req.JSONRequester.get(creds, url, receiver)
       } val)
     h.dispose_when_done(listener)
 
@@ -270,7 +270,7 @@ class \nodoc\ _TestJsonRequesterPostSuccess is UnitTest
       } val
     let listener = _MockHTTPListener(h, port, sslctx, responder,
       {()(creds, url, receiver) =>
-        req.JsonRequester.post(creds, url, "{}", receiver)
+        req.JSONRequester.post(creds, url, "{}", receiver)
       } val)
     h.dispose_when_done(listener)
 
@@ -304,7 +304,7 @@ class \nodoc\ _TestJsonRequesterGetRedirect is UnitTest
       } val
     let listener = _MockHTTPListener(h, port, sslctx, responder,
       {()(creds, url, receiver) =>
-        req.JsonRequester.get(creds, url, receiver)
+        req.JSONRequester.get(creds, url, receiver)
       } val)
     h.dispose_when_done(listener)
 
@@ -332,7 +332,7 @@ class \nodoc\ _TestJsonRequesterGetParseError is UnitTest
       } val
     let listener = _MockHTTPListener(h, port, sslctx, responder,
       {()(creds, url, receiver) =>
-        req.JsonRequester.get(creds, url, receiver)
+        req.JSONRequester.get(creds, url, receiver)
       } val)
     h.dispose_when_done(listener)
 
@@ -574,7 +574,7 @@ class \nodoc\ _TestBearerTokenSent is UnitTest
       } val
     let listener = _MockHTTPListener(h, port, sslctx, responder,
       {()(creds, url, receiver) =>
-        req.JsonRequester.get(creds, url, receiver)
+        req.JSONRequester.get(creds, url, receiver)
       } val)
     h.dispose_when_done(listener)
 
@@ -604,7 +604,7 @@ class \nodoc\ _TestNoTokenNoAuthHeader is UnitTest
       } val
     let listener = _MockHTTPListener(h, port, sslctx, responder,
       {()(creds, url, receiver) =>
-        req.JsonRequester.get(creds, url, receiver)
+        req.JSONRequester.get(creds, url, receiver)
       } val)
     h.dispose_when_done(listener)
 

--- a/github_rest_api/_test_result_receivers.pony
+++ b/github_rest_api/_test_result_receivers.pony
@@ -4,8 +4,8 @@ use "promises"
 use "pony_test"
 use req = "request"
 
-primitive \nodoc\ _TestStringConverter is req.JsonConverter[String]
-  fun apply(json: JsonNav, creds: req.Credentials): String ? =>
+primitive \nodoc\ _TestStringConverter is req.JSONConverter[String]
+  fun apply(json: JSONNav, creds: req.Credentials): String ? =>
     json("value").as_string()?
 
 class \nodoc\ _TestDeletedResultReceiverSuccess is UnitTest
@@ -132,8 +132,8 @@ class \nodoc\ _TestResultReceiverSuccess is UnitTest
     let creds = req.Credentials(lori.TCPConnectAuth(h.env.root))
     let receiver = req.ResultReceiver[String](
       creds, p, _TestStringConverter)
-    let obj = JsonObject.update("value", "hello")
-    receiver.success(JsonNav(obj))
+    let obj = JSONObject.update("value", "hello")
+    receiver.success(JSONNav(obj))
 
 class \nodoc\ _TestResultReceiverConverterError is UnitTest
   fun name(): String => "result-receivers/json/converter-error"
@@ -158,7 +158,7 @@ class \nodoc\ _TestResultReceiverConverterError is UnitTest
     let creds = req.Credentials(lori.TCPConnectAuth(h.env.root))
     let receiver = req.ResultReceiver[String](
       creds, p, _TestStringConverter)
-    receiver.success(JsonNav(JsonObject))
+    receiver.success(JSONNav(JSONObject))
 
 class \nodoc\ _TestResultReceiverFailure is UnitTest
   fun name(): String => "result-receivers/json/failure"
@@ -213,9 +213,9 @@ class \nodoc\ _TestPaginatedResultReceiverSuccess is UnitTest
       creds, _TestStringConverter)
     let receiver = PaginatedResultReceiver[String](
       creds, p, converter)
-    let arr = JsonArray
-      .push(JsonObject.update("value", "item1"))
-    receiver.success(JsonNav(arr), "")
+    let arr = JSONArray
+      .push(JSONObject.update("value", "item1"))
+    receiver.success(JSONNav(arr), "")
 
 class \nodoc\ _TestPaginatedResultReceiverConverterError is UnitTest
   fun name(): String =>
@@ -243,7 +243,7 @@ class \nodoc\ _TestPaginatedResultReceiverConverterError is UnitTest
       creds, _TestStringConverter)
     let receiver = PaginatedResultReceiver[String](
       creds, p, converter)
-    receiver.success(JsonNav("not-an-array"), "")
+    receiver.success(JSONNav("not-an-array"), "")
 
 class \nodoc\ _TestPaginatedResultReceiverFailure is UnitTest
   fun name(): String => "result-receivers/paginated/failure"
@@ -302,13 +302,13 @@ class \nodoc\ _TestSearchResultReceiverSuccess is UnitTest
       creds, _TestStringConverter)
     let receiver = SearchResultReceiver[String](
       creds, p, converter)
-    let items_arr = JsonArray
-      .push(JsonObject.update("value", "result1"))
-    let envelope = JsonObject
+    let items_arr = JSONArray
+      .push(JSONObject.update("value", "result1"))
+    let envelope = JSONObject
       .update("total_count", I64(42))
       .update("incomplete_results", false)
       .update("items", items_arr)
-    receiver.success(JsonNav(envelope), "")
+    receiver.success(JSONNav(envelope), "")
 
 class \nodoc\ _TestSearchResultReceiverConverterError is UnitTest
   fun name(): String =>
@@ -336,7 +336,7 @@ class \nodoc\ _TestSearchResultReceiverConverterError is UnitTest
       creds, _TestStringConverter)
     let receiver = SearchResultReceiver[String](
       creds, p, converter)
-    receiver.success(JsonNav(JsonObject), "")
+    receiver.success(JSONNav(JSONObject), "")
 
 class \nodoc\ _TestSearchResultReceiverFailure is UnitTest
   fun name(): String => "result-receivers/search/failure"

--- a/github_rest_api/_test_search_and_pagination.pony
+++ b/github_rest_api/_test_search_and_pagination.pony
@@ -15,10 +15,10 @@ class \nodoc\ _TestSearchConverterExtractsLinks is UnitTest
     let creds = req.Credentials(lori.TCPConnectAuth(h.env.root))
     let converter = PaginatedSearchJsonConverter[String](
       creds, _TestStringConverter)
-    let items_arr = JsonArray
-      .push(JsonObject.update("value", "a"))
-      .push(JsonObject.update("value", "b"))
-    let envelope = JsonObject
+    let items_arr = JSONArray
+      .push(JSONObject.update("value", "a"))
+      .push(JSONObject.update("value", "b"))
+    let envelope = JSONObject
       .update("total_count", I64(10))
       .update("incomplete_results", true)
       .update("items", items_arr)
@@ -27,7 +27,7 @@ class \nodoc\ _TestSearchConverterExtractsLinks is UnitTest
         + "<https://example.com/next>; rel=\"next\""
     end
     try
-      let sr = converter(JsonNav(envelope), link, creds)?
+      let sr = converter(JSONNav(envelope), link, creds)?
       h.assert_eq[I64](10, sr.total_count)
       h.assert_true(sr.incomplete_results)
       h.assert_eq[USize](2, sr.items.size())
@@ -51,14 +51,14 @@ class \nodoc\ _TestSearchConverterNoLinks is UnitTest
     let creds = req.Credentials(lori.TCPConnectAuth(h.env.root))
     let converter = PaginatedSearchJsonConverter[String](
       creds, _TestStringConverter)
-    let items_arr = JsonArray
-      .push(JsonObject.update("value", "x"))
-    let envelope = JsonObject
+    let items_arr = JSONArray
+      .push(JSONObject.update("value", "x"))
+    let envelope = JSONObject
       .update("total_count", I64(1))
       .update("incomplete_results", false)
       .update("items", items_arr)
     try
-      let sr = converter(JsonNav(envelope), "", creds)?
+      let sr = converter(JSONNav(envelope), "", creds)?
       h.assert_eq[USize](1, sr.items.size())
       h.assert_eq[String]("x", sr.items(0)?)
       h.assert_true(sr.next_page() is None,
@@ -79,15 +79,15 @@ class \nodoc\ _TestListConverterExtractsLinks is UnitTest
     let creds = req.Credentials(lori.TCPConnectAuth(h.env.root))
     let converter = PaginatedListJsonConverter[String](
       creds, _TestStringConverter)
-    let arr = JsonArray
-      .push(JsonObject.update("value", "p"))
-      .push(JsonObject.update("value", "q"))
+    let arr = JSONArray
+      .push(JSONObject.update("value", "p"))
+      .push(JSONObject.update("value", "q"))
     let link = recover val
       "<https://example.com/prev>; rel=\"prev\", "
         + "<https://example.com/next>; rel=\"next\""
     end
     try
-      let pl = converter(JsonNav(arr), link, creds)?
+      let pl = converter(JSONNav(arr), link, creds)?
       h.assert_eq[USize](2, pl.results.size())
       h.assert_eq[String]("p", pl.results(0)?)
       h.assert_eq[String]("q", pl.results(1)?)
@@ -109,10 +109,10 @@ class \nodoc\ _TestListConverterNoLinks is UnitTest
     let creds = req.Credentials(lori.TCPConnectAuth(h.env.root))
     let converter = PaginatedListJsonConverter[String](
       creds, _TestStringConverter)
-    let arr = JsonArray
-      .push(JsonObject.update("value", "z"))
+    let arr = JSONArray
+      .push(JSONObject.update("value", "z"))
     try
-      let pl = converter(JsonNav(arr), "", creds)?
+      let pl = converter(JSONNav(arr), "", creds)?
       h.assert_eq[USize](1, pl.results.size())
       h.assert_eq[String]("z", pl.results(0)?)
       h.assert_true(pl.next_page() is None,

--- a/github_rest_api/asset.pony
+++ b/github_rest_api/asset.pony
@@ -53,15 +53,15 @@ class val Asset
     url = url'
     browser_download_url = browser_download_url'
 
-primitive AssetJsonConverter is req.JsonConverter[Asset]
+primitive AssetJsonConverter is req.JSONConverter[Asset]
   """
   Converts a JSON object into an Asset.
   """
-  fun apply(json: JsonNav, creds: req.Credentials): Asset ? =>
+  fun apply(json: JSONNav, creds: req.Credentials): Asset ? =>
     let id = json("id").as_i64()?
     let node_id = json("node_id").as_string()?
     let name = json("name").as_string()?
-    let label = JsonNavUtil.string_or_none(json("label"))?
+    let label = JSONNavUtil.string_or_none(json("label"))?
     let uploader = UserJsonConverter(json("uploader"), creds)?
     let content_type = json("content_type").as_string()?
     let state = json("state").as_string()?

--- a/github_rest_api/commit.pony
+++ b/github_rest_api/commit.pony
@@ -60,19 +60,19 @@ primitive GetCommit
     let p = Promise[CommitOrError]
     let receiver = req.ResultReceiver[Commit](creds, p, CommitJsonConverter)
 
-    req.JsonRequester.get(creds, url, receiver)
+    req.JSONRequester.get(creds, url, receiver)
     p
 
-primitive CommitJsonConverter is req.JsonConverter[Commit]
+primitive CommitJsonConverter is req.JSONConverter[Commit]
   """
   Converts a JSON object from the commits API into a Commit.
   """
-  fun apply(json: JsonNav, creds: req.Credentials): Commit ? =>
+  fun apply(json: JSONNav, creds: req.Credentials): Commit ? =>
     let sha = json("sha").as_string()?
 
     let files = recover trn Array[CommitFile] end
     for f in json("files").as_array()?.values() do
-      let file = CommitFileJsonConverter(JsonNav(f), creds)?
+      let file = CommitFileJsonConverter(JSONNav(f), creds)?
       files.push(file)
     end
 

--- a/github_rest_api/commit_file.pony
+++ b/github_rest_api/commit_file.pony
@@ -21,11 +21,11 @@ class val CommitFile
     status = status'
     filename = filename'
 
-primitive CommitFileJsonConverter is req.JsonConverter[CommitFile]
+primitive CommitFileJsonConverter is req.JSONConverter[CommitFile]
   """
   Converts a JSON object into a CommitFile.
   """
-  fun apply(json: JsonNav,
+  fun apply(json: JSONNav,
     creds: req.Credentials): CommitFile ?
   =>
     let sha = json("sha").as_string()?

--- a/github_rest_api/gist.pony
+++ b/github_rest_api/gist.pony
@@ -181,7 +181,7 @@ primitive GetGist
     let p = Promise[GistOrError]
     let r = req.ResultReceiver[Gist](creds, p, GistJsonConverter)
 
-    req.JsonRequester.get(creds, url, r)
+    req.JSONRequester.get(creds, url, r)
     p
 
 primitive CreateGist
@@ -209,13 +209,13 @@ primitive CreateGist
     let p = Promise[GistOrError]
     let r = req.ResultReceiver[Gist](creds, p, GistJsonConverter)
 
-    var files_obj = JsonObject
+    var files_obj = JSONObject
     for (name, content) in files.values() do
       files_obj = files_obj.update(name,
-        JsonObject.update("content", content))
+        JSONObject.update("content", content))
     end
 
-    var obj = JsonObject
+    var obj = JSONObject
       .update("files", files_obj)
       .update("public", is_public)
     match description
@@ -223,7 +223,7 @@ primitive CreateGist
     end
     let json = obj.print()
 
-    req.JsonRequester.post(creds, url, consume json, r)
+    req.JSONRequester.post(creds, url, consume json, r)
     p
 
 primitive UpdateGist
@@ -257,14 +257,14 @@ primitive UpdateGist
     let p = Promise[GistOrError]
     let r = req.ResultReceiver[Gist](creds, p, GistJsonConverter)
 
-    var files_obj = JsonObject
+    var files_obj = JSONObject
     for (name, update) in files.values() do
       match \exhaustive\ update
       | let edit: GistFileEdit =>
         files_obj = files_obj.update(name,
-          JsonObject.update("content", edit.content))
+          JSONObject.update("content", edit.content))
       | let rename: GistFileRename =>
-        var entry = JsonObject.update("filename", rename.filename)
+        var entry = JSONObject.update("filename", rename.filename)
         match rename.content
         | let c: String => entry = entry.update("content", c)
         end
@@ -274,13 +274,13 @@ primitive UpdateGist
       end
     end
 
-    var obj = JsonObject.update("files", files_obj)
+    var obj = JSONObject.update("files", files_obj)
     match description
     | let d: String => obj = obj.update("description", d)
     end
     let json = obj.print()
 
-    req.JsonRequester.patch(creds, url, consume json, r)
+    req.JSONRequester.patch(creds, url, consume json, r)
     p
 
 primitive DeleteGist
@@ -403,7 +403,7 @@ primitive ForkGist
     let p = Promise[GistOrError]
     let r = req.ResultReceiver[Gist](creds, p, GistJsonConverter)
 
-    req.JsonRequester.post(creds, url, "", r)
+    req.JSONRequester.post(creds, url, "", r)
     p
 
 primitive GetGistForks
@@ -560,23 +560,23 @@ primitive _GetPaginatedGists
     LinkedJsonRequester(creds, url, r)
     p
 
-primitive GistJsonConverter is req.JsonConverter[Gist]
+primitive GistJsonConverter is req.JSONConverter[Gist]
   """
   Converts a JSON object from the GitHub gist API into a Gist. Handles the
   files object by iterating its key-value pairs and converting each value with
   GistFileJsonConverter.
   """
-  fun apply(json: JsonNav, creds: req.Credentials): Gist ? =>
+  fun apply(json: JSONNav, creds: req.Credentials): Gist ? =>
     let id = json("id").as_string()?
     let node_id = json("node_id").as_string()?
-    let description = JsonNavUtil.string_or_none(json("description"))?
+    let description = JSONNavUtil.string_or_none(json("description"))?
     let public = json("public").as_bool()?
     let owner = try UserJsonConverter(json("owner"), creds)? else None end
     let user = try UserJsonConverter(json("user"), creds)? else None end
 
     let files = recover trn Array[(String, GistFile)] end
     for (name, value) in json("files").as_object()?.pairs() do
-      let gf = GistFileJsonConverter(JsonNav(value), creds)?
+      let gf = GistFileJsonConverter(JSONNav(value), creds)?
       files.push((name, gf))
     end
 

--- a/github_rest_api/gist_comment.pony
+++ b/github_rest_api/gist_comment.pony
@@ -81,7 +81,7 @@ primitive GetGistComment
       p,
       GistCommentJsonConverter)
 
-    req.JsonRequester.get(creds, url, r)
+    req.JSONRequester.get(creds, url, r)
     p
 
 primitive GetGistComments
@@ -145,8 +145,8 @@ primitive CreateGistComment
       p,
       GistCommentJsonConverter)
 
-    let json = JsonObject.update("body", body).print()
-    req.JsonRequester.post(creds, url, consume json, r)
+    let json = JSONObject.update("body", body).print()
+    req.JSONRequester.post(creds, url, consume json, r)
     p
 
 primitive UpdateGistComment
@@ -180,8 +180,8 @@ primitive UpdateGistComment
       p,
       GistCommentJsonConverter)
 
-    let json = JsonObject.update("body", body).print()
-    req.JsonRequester.patch(creds, url, consume json, r)
+    let json = JSONObject.update("body", body).print()
+    req.JSONRequester.patch(creds, url, consume json, r)
     p
 
 primitive DeleteGistComment
@@ -214,11 +214,11 @@ primitive DeleteGistComment
     req.NoContentRequester.delete(creds, url, r)
     p
 
-primitive GistCommentJsonConverter is req.JsonConverter[GistComment]
+primitive GistCommentJsonConverter is req.JSONConverter[GistComment]
   """
   Converts a JSON object from the gist comments API into a GistComment.
   """
-  fun apply(json: JsonNav, creds: req.Credentials): GistComment ? =>
+  fun apply(json: JSONNav, creds: req.Credentials): GistComment ? =>
     let id = json("id").as_i64()?
     let node_id = json("node_id").as_string()?
     let url = json("url").as_string()?

--- a/github_rest_api/gist_commit.pony
+++ b/github_rest_api/gist_commit.pony
@@ -14,12 +14,12 @@ class val GistChangeStatus
     deletions = deletions'
     total = total'
 
-primitive GistChangeStatusJsonConverter is req.JsonConverter[GistChangeStatus]
+primitive GistChangeStatusJsonConverter is req.JSONConverter[GistChangeStatus]
   """
   Converts a JSON object representing a gist commit's change_status into a
   GistChangeStatus.
   """
-  fun apply(json: JsonNav, creds: req.Credentials): GistChangeStatus ? =>
+  fun apply(json: JSONNav, creds: req.Credentials): GistChangeStatus ? =>
     let additions = json("additions").as_i64()?
     let deletions = json("deletions").as_i64()?
     let total = json("total").as_i64()?
@@ -52,11 +52,11 @@ class val GistCommit
     change_status = change_status'
     user = user'
 
-primitive GistCommitJsonConverter is req.JsonConverter[GistCommit]
+primitive GistCommitJsonConverter is req.JSONConverter[GistCommit]
   """
   Converts a JSON object from the gist commits endpoint into a GistCommit.
   """
-  fun apply(json: JsonNav, creds: req.Credentials): GistCommit ? =>
+  fun apply(json: JSONNav, creds: req.Credentials): GistCommit ? =>
     let version = json("version").as_string()?
     let url = json("url").as_string()?
     let committed_at = json("committed_at").as_string()?

--- a/github_rest_api/gist_file.pony
+++ b/github_rest_api/gist_file.pony
@@ -37,21 +37,21 @@ class val GistFile
     encoding = encoding'
     truncated = truncated'
 
-primitive GistFileJsonConverter is req.JsonConverter[GistFile]
+primitive GistFileJsonConverter is req.JSONConverter[GistFile]
   """
   Converts a JSON object representing a single gist file into a GistFile.
   Optional fields that may be absent in list responses are extracted with
   try/else None.
   """
-  fun apply(json: JsonNav, creds: req.Credentials): GistFile ? =>
+  fun apply(json: JSONNav, creds: req.Credentials): GistFile ? =>
     let filename = json("filename").as_string()?
     let content_type = json("type").as_string()?
-    let language = JsonNavUtil.string_or_none(json("language"))?
+    let language = JSONNavUtil.string_or_none(json("language"))?
     let raw_url = json("raw_url").as_string()?
     let size = json("size").as_i64()?
-    let content = try JsonNavUtil.string_or_none(json("content"))? else None end
+    let content = try JSONNavUtil.string_or_none(json("content"))? else None end
     let encoding =
-      try JsonNavUtil.string_or_none(json("encoding"))? else None end
+      try JSONNavUtil.string_or_none(json("encoding"))? else None end
     let truncated = try json("truncated").as_bool()? else None end
 
     GistFile(filename,

--- a/github_rest_api/git_commit.pony
+++ b/github_rest_api/git_commit.pony
@@ -25,11 +25,11 @@ class val GitCommit
     message = message'
     url = url'
 
-primitive GitCommitJsonConverter is req.JsonConverter[GitCommit]
+primitive GitCommitJsonConverter is req.JSONConverter[GitCommit]
   """
   Converts a JSON object into a GitCommit.
   """
-  fun apply(json: JsonNav, creds: req.Credentials): GitCommit ? =>
+  fun apply(json: JSONNav, creds: req.Credentials): GitCommit ? =>
     let author = GitPersonJsonConverter(json("author"), creds)?
     let committer = GitPersonJsonConverter(json("committer"), creds)?
     let message = json("message").as_string()?

--- a/github_rest_api/git_person.pony
+++ b/github_rest_api/git_person.pony
@@ -12,11 +12,11 @@ class val GitPerson
     name = name'
     email = email'
 
-primitive GitPersonJsonConverter is req.JsonConverter[GitPerson]
+primitive GitPersonJsonConverter is req.JSONConverter[GitPerson]
   """
   Converts a JSON object into a GitPerson.
   """
-  fun apply(json: JsonNav, creds: req.Credentials): GitPerson ? =>
+  fun apply(json: JSONNav, creds: req.Credentials): GitPerson ? =>
     let name = json("name").as_string()?
     let email = json("email").as_string()?
 

--- a/github_rest_api/issue.pony
+++ b/github_rest_api/issue.pony
@@ -159,7 +159,7 @@ primitive GetIssue
     let p = Promise[IssueOrError]
     let receiver = req.ResultReceiver[Issue](creds, p, IssueJsonConverter)
 
-    req.JsonRequester.get(creds, url, receiver)
+    req.JSONRequester.get(creds, url, receiver)
     p
 
 primitive GetRepositoryIssues
@@ -220,11 +220,11 @@ primitive GetRepositoryIssues
     p
 
 
-primitive IssueJsonConverter is req.JsonConverter[Issue]
+primitive IssueJsonConverter is req.JSONConverter[Issue]
   """
   Converts a JSON object from the issues API into an Issue.
   """
-  fun apply(json: JsonNav, creds: req.Credentials): Issue ? =>
+  fun apply(json: JSONNav, creds: req.Credentials): Issue ? =>
     let url = json("url").as_string()?
     let respository_url = json("repository_url").as_string()?
     let labels_url = json("labels_url").as_string()?
@@ -235,18 +235,18 @@ primitive IssueJsonConverter is req.JsonConverter[Issue]
     let number = json("number").as_i64()?
     let title = json("title").as_string()?
     let user = UserJsonConverter(json("user"), creds)?
-    let state = JsonNavUtil.string_or_none(json("state"))?
-    let body = JsonNavUtil.string_or_none(json("body"))?
+    let state = JSONNavUtil.string_or_none(json("state"))?
+    let body = JSONNavUtil.string_or_none(json("body"))?
 
     let labels = recover trn Array[Label] end
     for i in json("labels").as_array()?.values() do
-      let l = LabelJsonConverter(JsonNav(i), creds)?
+      let l = LabelJsonConverter(JSONNav(i), creds)?
       labels.push(l)
     end
 
     let pr_json = json("pull_request")
     let pull_request = match pr_json.json()
-    | let _: JsonValue =>
+    | let _: JSONValue =>
       IssuePullRequestJsonConverter(pr_json, creds)?
     else
       None

--- a/github_rest_api/issue_comment.pony
+++ b/github_rest_api/issue_comment.pony
@@ -58,8 +58,8 @@ primitive CreateIssueComment
       p,
       IssueCommentJsonConverter)
 
-    let json = JsonObject.update("body", comment).print()
-    req.JsonRequester.post(creds, url, consume json, r)
+    let json = JSONObject.update("body", comment).print()
+    req.JSONRequester.post(creds, url, consume json, r)
     p
 
 primitive GetIssueComments
@@ -87,7 +87,7 @@ primitive GetIssueComments
       p,
       IssueCommentsJsonConverter)
 
-    req.JsonRequester.get(creds, url, r)
+    req.JSONRequester.get(creds, url, r)
     p
 
 primitive IssueCommentsURL
@@ -110,11 +110,11 @@ primitive IssueCommentsURL
       e
     end
 
-primitive IssueCommentJsonConverter is req.JsonConverter[IssueComment]
+primitive IssueCommentJsonConverter is req.JSONConverter[IssueComment]
   """
   Converts a JSON object into an IssueComment.
   """
-  fun apply(json: JsonNav,
+  fun apply(json: JSONNav,
     creds: req.Credentials): IssueComment ?
   =>
     let body = json("body").as_string()?
@@ -124,17 +124,17 @@ primitive IssueCommentJsonConverter is req.JsonConverter[IssueComment]
 
     IssueComment(creds, body, url, html_url, issue_url)
 
-primitive IssueCommentsJsonConverter is req.JsonConverter[Array[IssueComment] val]
+primitive IssueCommentsJsonConverter is req.JSONConverter[Array[IssueComment] val]
   """
   Converts a JSON array of issue comment objects into an Array of IssueComment.
   """
-  fun apply(json: JsonNav,
+  fun apply(json: JSONNav,
     creds: req.Credentials): Array[IssueComment] val ?
   =>
     let comments = recover trn Array[IssueComment] end
 
     for i in json.as_array()?.values() do
-      let comment = IssueCommentJsonConverter(JsonNav(i), creds)?
+      let comment = IssueCommentJsonConverter(JSONNav(i), creds)?
       comments.push(comment)
     end
 

--- a/github_rest_api/issue_pull_request.pony
+++ b/github_rest_api/issue_pull_request.pony
@@ -28,15 +28,15 @@ class val IssuePullRequest
     patch_url = patch_url'
     merged_at = merged_at'
 
-primitive IssuePullRequestJsonConverter is req.JsonConverter[IssuePullRequest]
+primitive IssuePullRequestJsonConverter is req.JSONConverter[IssuePullRequest]
   """
   Converts a JSON object into an IssuePullRequest.
   """
-  fun apply(json: JsonNav, creds: req.Credentials): IssuePullRequest ? =>
+  fun apply(json: JSONNav, creds: req.Credentials): IssuePullRequest ? =>
     let url = json("url").as_string()?
     let html_url = json("html_url").as_string()?
     let diff_url = json("diff_url").as_string()?
     let patch_url = json("patch_url").as_string()?
-    let merged_at = JsonNavUtil.string_or_none(json("merged_at"))?
+    let merged_at = JSONNavUtil.string_or_none(json("merged_at"))?
 
     IssuePullRequest(url, html_url, diff_url, patch_url, merged_at)

--- a/github_rest_api/json_nav_util.pony
+++ b/github_rest_api/json_nav_util.pony
@@ -1,15 +1,15 @@
 use "json"
 
-primitive JsonNavUtil
+primitive JSONNavUtil
   """
   Utility for extracting optional string fields from JSON.
 
-  JsonNav does not have an as_string_or_none() method. This primitive provides
-  equivalent functionality: given a JsonNav positioned on a field, it returns
+  JSONNav does not have an as_string_or_none() method. This primitive provides
+  equivalent functionality: given a JSONNav positioned on a field, it returns
   the String value if present or None if the JSON value is null. Raises an
   error if the navigation failed (key missing) or the value is any other type.
   """
-  fun string_or_none(json: JsonNav): (String | None) ? =>
+  fun string_or_none(json: JSONNav): (String | None) ? =>
     match json.json()
     | let s: String => s
     | None => None

--- a/github_rest_api/label.pony
+++ b/github_rest_api/label.pony
@@ -71,7 +71,7 @@ primitive CreateLabel
       p,
       LabelJsonConverter)
 
-    var obj = JsonObject.update("name", name)
+    var obj = JSONObject.update("name", name)
     match color
     | let c: String => obj = obj.update("color", c)
     end
@@ -79,7 +79,7 @@ primitive CreateLabel
     | let d: String => obj = obj.update("description", d)
     end
     let json = obj.print()
-    req.JsonRequester.post(creds, url, consume json, r)
+    req.JSONRequester.post(creds, url, consume json, r)
     p
 
 primitive DeleteLabel
@@ -116,18 +116,18 @@ primitive DeleteLabel
     req.NoContentRequester.delete(creds, url, r)
     p
 
-primitive LabelJsonConverter is req.JsonConverter[Label]
+primitive LabelJsonConverter is req.JSONConverter[Label]
   """
   Converts a JSON object into a Label.
   """
-  fun apply(json: JsonNav, creds: req.Credentials): Label ? =>
+  fun apply(json: JSONNav, creds: req.Credentials): Label ? =>
     let id = json("id").as_i64()?
     let node_id = json("node_id").as_string()?
     let url = json("url").as_string()?
     let name = json("name").as_string()?
     let color = json("color").as_string()?
     let default = json("default").as_bool()?
-    let description = JsonNavUtil.string_or_none(json("description"))?
+    let description = JSONNavUtil.string_or_none(json("description"))?
 
     Label(creds,
       id,

--- a/github_rest_api/license.pony
+++ b/github_rest_api/license.pony
@@ -27,11 +27,11 @@ class val License
     spdx_id = spdx_id'
     url = url'
 
-primitive LicenseJsonConverter is req.JsonConverter[License]
+primitive LicenseJsonConverter is req.JSONConverter[License]
   """
   Converts a JSON object into a License.
   """
-  fun apply(json: JsonNav, creds: req.Credentials): License ? =>
+  fun apply(json: JSONNav, creds: req.Credentials): License ? =>
     let node_id = json("node_id").as_string()?
     let name = json("name").as_string()?
     let key = json("key").as_string()?

--- a/github_rest_api/paginated_list.pony
+++ b/github_rest_api/paginated_list.pony
@@ -11,7 +11,7 @@ interface tag LinkedResultReceiver
   Receives the result of an HTTP GET request that returns JSON along with a
   Link header. Used by both paginated list and search result requesters.
   """
-  be success(json: JsonNav, link_header: String)
+  be success(json: JSONNav, link_header: String)
   be failure(status: U16, response_body: String, message: String)
 
 class val PaginatedList[A: Any val]
@@ -28,7 +28,7 @@ class val PaginatedList[A: Any val]
   let results: Array[A] val
 
   new val _from_array(creds: req.Credentials,
-    converter: req.JsonConverter[A],
+    converter: req.JSONConverter[A],
     results': Array[A] val,
     prev_link: (String | None) = None,
     next_link: (String | None) = None)
@@ -73,23 +73,23 @@ class val PaginatedListJsonConverter[A: Any val]
   """
   Converts a JSON array response with Link header pagination into a
   PaginatedList. Delegates individual item conversion to the wrapped
-  JsonConverter.
+  JSONConverter.
   """
   let _creds: req.Credentials
-  let _converter: req.JsonConverter[A]
+  let _converter: req.JSONConverter[A]
 
-  new val create(creds: req.Credentials, converter: req.JsonConverter[A]) =>
+  new val create(creds: req.Credentials, converter: req.JSONConverter[A]) =>
     _creds = creds
     _converter = converter
 
-  fun apply(json: JsonNav,
+  fun apply(json: JSONNav,
     link_header: String,
     creds: req.Credentials): PaginatedList[A] ?
   =>
     let entries = recover trn Array[A] end
 
     for i in json.as_array()?.values() do
-      let e = _converter(JsonNav(i), creds)?
+      let e = _converter(JSONNav(i), creds)?
       entries.push(e)
     end
 
@@ -118,12 +118,12 @@ actor PaginatedResultReceiver[A: Any val]
     _p = p
     _converter = c
 
-  be success(json: JsonNav, link_header: String) =>
+  be success(json: JSONNav, link_header: String) =>
     try
       _p(_converter(json, link_header, _creds)?)
     else
       let m = recover val
-        "Unable to convert json for " + req.JsonTypeString(json)
+        "Unable to convert json for " + req.JSONTypeString(json)
       end
 
       _p(req.RequestError(where message' = m))
@@ -234,9 +234,9 @@ actor LinkedJsonRequester is courier.HTTPClientConnectionActor
       let response = _collector.build()?
       if _status == 200 then
         match \exhaustive\ courier.ResponseJSON(response)
-        | let json: JsonValue =>
-          _receiver.success(JsonNav(json), _link_header)
-        | let _: JsonParseError =>
+        | let json: JSONValue =>
+          _receiver.success(JSONNav(json), _link_header)
+        | let _: JSONParseError =>
           _receiver.failure(_status, "", "Failed to parse response")
         end
       else

--- a/github_rest_api/pull_request.pony
+++ b/github_rest_api/pull_request.pony
@@ -81,22 +81,22 @@ primitive GetPullRequest
       p,
       PullRequestJsonConverter)
 
-    req.JsonRequester.get(creds, url, r)
+    req.JSONRequester.get(creds, url, r)
     p
 
-primitive PullRequestJsonConverter is req.JsonConverter[PullRequest]
+primitive PullRequestJsonConverter is req.JSONConverter[PullRequest]
   """
   Converts a JSON object from the pulls API into a PullRequest.
   """
-  fun apply(json: JsonNav, creds: req.Credentials): PullRequest ? =>
+  fun apply(json: JSONNav, creds: req.Credentials): PullRequest ? =>
     let number = json("number").as_i64()?
     let title = json("title").as_string()?
-    let body = JsonNavUtil.string_or_none(json("body"))?
+    let body = JSONNavUtil.string_or_none(json("body"))?
     let state = json("state").as_string()?
 
     let labels = recover trn Array[Label] end
     for i in json("labels").as_array()?.values() do
-      let l = LabelJsonConverter(JsonNav(i), creds)?
+      let l = LabelJsonConverter(JSONNav(i), creds)?
       labels.push(l)
     end
 

--- a/github_rest_api/pull_request_base.pony
+++ b/github_rest_api/pull_request_base.pony
@@ -27,11 +27,11 @@ class val PullRequestBase
     user = user'
     repo = repo'
 
-primitive PullRequestBaseJsonConverter is req.JsonConverter[PullRequestBase]
+primitive PullRequestBaseJsonConverter is req.JSONConverter[PullRequestBase]
   """
   Converts a JSON object into a PullRequestBase.
   """
-  fun apply(json: JsonNav, creds: req.Credentials): PullRequestBase ? =>
+  fun apply(json: JSONNav, creds: req.Credentials): PullRequestBase ? =>
     let label = json("label").as_string()?
     let reference = json("ref").as_string()?
     let sha = json("sha").as_string()?

--- a/github_rest_api/pull_request_file.pony
+++ b/github_rest_api/pull_request_file.pony
@@ -48,22 +48,22 @@ primitive GetPullRequestFiles
       p,
       PullRequestFilesJsonConverter)
 
-    req.JsonRequester.get(creds, url, r)
+    req.JSONRequester.get(creds, url, r)
     p
 
 primitive PullRequestFilesJsonConverter is
-  req.JsonConverter[Array[PullRequestFile] val]
+  req.JSONConverter[Array[PullRequestFile] val]
   """
   Converts a JSON array of pull request file objects into an Array of
   PullRequestFile.
   """
-  fun apply(json: JsonNav,
+  fun apply(json: JSONNav,
     creds: req.Credentials): Array[PullRequestFile] val ?
   =>
     let files = recover trn Array[PullRequestFile] end
 
     for i in json.as_array()?.values() do
-      let json_i = JsonNav(i)
+      let json_i = JSONNav(i)
       let filename = json_i("filename").as_string()?
       let file = PullRequestFile(creds, filename)
       files.push(file)

--- a/github_rest_api/release.pony
+++ b/github_rest_api/release.pony
@@ -120,7 +120,7 @@ primitive CreateRelease
       p,
       ReleaseJsonConverter)
 
-    var obj = JsonObject
+    var obj = JSONObject
       .update("tag_name", tag_name)
       .update("name", name)
       .update("body", body)
@@ -130,14 +130,14 @@ primitive CreateRelease
     end
     obj = obj.update("draft", draft).update("prerelease", prerelease)
     let json = obj.print()
-    req.JsonRequester.post(creds, url, consume json, r)
+    req.JSONRequester.post(creds, url, consume json, r)
     p
 
-primitive ReleaseJsonConverter is req.JsonConverter[Release]
+primitive ReleaseJsonConverter is req.JSONConverter[Release]
   """
   Converts a JSON object from the releases API into a Release.
   """
-  fun apply(json: JsonNav, creds: req.Credentials): Release ? =>
+  fun apply(json: JSONNav, creds: req.Credentials): Release ? =>
     let id = json("id").as_i64()?
     let node_id = json("node_id").as_string()?
     let author = UserJsonConverter(json("author"), creds)?
@@ -152,7 +152,7 @@ primitive ReleaseJsonConverter is req.JsonConverter[Release]
 
     let assets = recover trn Array[Asset] end
     for i in json("assets").as_array()?.values() do
-      let a = AssetJsonConverter(JsonNav(i), creds)?
+      let a = AssetJsonConverter(JSONNav(i), creds)?
       assets.push(a)
     end
 

--- a/github_rest_api/repository.pony
+++ b/github_rest_api/repository.pony
@@ -410,7 +410,7 @@ primitive GetRepository
       p,
       RepositoryJsonConverter)
 
-    req.JsonRequester.get(creds, url, r)
+    req.JSONRequester.get(creds, url, r)
     p
 
 primitive GetRepositoryLabels
@@ -474,25 +474,25 @@ primitive GetOrganizationRepositories
     LinkedJsonRequester(creds, url, r)
     p
 
-primitive RepositoryJsonConverter is req.JsonConverter[Repository]
+primitive RepositoryJsonConverter is req.JSONConverter[Repository]
   """
   Converts a JSON object from the repositories API into a Repository.
   """
-  fun apply(json: JsonNav,
+  fun apply(json: JSONNav,
     creds: req.Credentials): Repository ?
   =>
     let id = json("id").as_i64()?
     let node_id = json("node_id").as_string()?
     let name = json("name").as_string()?
     let full_name = json("full_name").as_string()?
-    let description = JsonNavUtil.string_or_none(json("description"))?
+    let description = JSONNavUtil.string_or_none(json("description"))?
     let owner = UserJsonConverter(json("owner"), creds)?
     let private = json("private").as_bool()?
     let fork = json("fork").as_bool()?
     let created_at = json("created_at").as_string()?
     let pushed_at = json("pushed_at").as_string()?
     let updated_at = json("updated_at").as_string()?
-    let homepage = JsonNavUtil.string_or_none(json("homepage"))?
+    let homepage = JSONNavUtil.string_or_none(json("homepage"))?
     let default_branch = json("default_branch").as_string()?
     let organization = try
       UserJsonConverter(json("organization"), creds)?
@@ -512,7 +512,7 @@ primitive RepositoryJsonConverter is req.JsonConverter[Repository]
       try json("subscribers_count").as_i64()? else None end
     let watchers = json("watchers").as_i64()?
     let watchers_count = json("watchers_count").as_i64()?
-    let language = JsonNavUtil.string_or_none(json("language"))?
+    let language = JSONNavUtil.string_or_none(json("language"))?
     let license = try
       LicenseJsonConverter(json("license"), creds)?
     else
@@ -565,7 +565,7 @@ primitive RepositoryJsonConverter is req.JsonConverter[Repository]
 
     let clone_url = json("clone_url").as_string()?
     let git_url = json("git_url").as_string()?
-    let mirror_url = JsonNavUtil.string_or_none(json("mirror_url"))?
+    let mirror_url = JSONNavUtil.string_or_none(json("mirror_url"))?
     let ssh_url = json("ssh_url").as_string()?
     let svn_url = json("svn_url").as_string()?
 

--- a/github_rest_api/request/credentials.pony
+++ b/github_rest_api/request/credentials.pony
@@ -27,27 +27,27 @@ class val Credentials
 actor ResultReceiver[A: Any val]
   """
   Generic receiver that converts a JSON response into a model type via a
-  JsonConverter and fulfills the associated Promise with the result or a
+  JSONConverter and fulfills the associated Promise with the result or a
   RequestError.
   """
   let _creds: Credentials
   let _p: Promise[(A | RequestError)]
-  let _converter: JsonConverter[A]
+  let _converter: JSONConverter[A]
 
   new create(creds: Credentials,
     p: Promise[(A | RequestError)],
-    c: JsonConverter[A])
+    c: JSONConverter[A])
   =>
     _creds = creds
     _p = p
     _converter = c
 
-  be success(json: JsonNav) =>
+  be success(json: JSONNav) =>
     try
       _p(_converter(json, _creds)?)
     else
       let m = recover val
-        "Unable to convert json for " + JsonTypeString(json)
+        "Unable to convert json for " + JSONTypeString(json)
       end
 
       _p(RequestError(where message' = m))

--- a/github_rest_api/request/json.pony
+++ b/github_rest_api/request/json.pony
@@ -1,18 +1,18 @@
 use "json"
 
-interface val JsonConverter[A: Any #share]
-  fun apply(json: JsonNav, creds: Credentials): A ?
+interface val JSONConverter[A: Any #share]
+  fun apply(json: JSONNav, creds: Credentials): A ?
 
-primitive JsonTypeString
-  """Convert a JsonNav's value to its JSON string representation for error messages."""
-  fun apply(json: JsonNav): String =>
+primitive JSONTypeString
+  """Convert a JSONNav's value to its JSON string representation for error messages."""
+  fun apply(json: JSONNav): String =>
     match \exhaustive\ json.json()
-    | let o: JsonObject => o.print()
-    | let a: JsonArray => a.print()
+    | let o: JSONObject => o.print()
+    | let a: JSONArray => a.print()
     | let s: String => s
     | let i: I64 => i.string()
     | let f: F64 => f.string()
     | let b: Bool => b.string()
     | None => "null"
-    | JsonNotFound => "JsonNotFound"
+    | JSONNotFound => "JSONNotFound"
     end

--- a/github_rest_api/request/json_requester.pony
+++ b/github_rest_api/request/json_requester.pony
@@ -3,15 +3,15 @@ use "json"
 use ssl = "ssl/net"
 use uri = "uri"
 
-interface tag JsonRequesterResultReceiver
+interface tag JSONRequesterResultReceiver
   """
   Receives the result of a JSON API request: either a parsed JSON response
   on success, or status/body/message details on failure.
   """
-  be success(json: JsonNav)
+  be success(json: JSONNav)
   be failure(status: U16, response_body: String, message: String)
 
-actor JsonRequester is courier.HTTPClientConnectionActor
+actor JSONRequester is courier.HTTPClientConnectionActor
   """
   Issues an HTTP request that expects a JSON response. Supports GET (200),
   POST (201), and PATCH (200) methods. GET requests follow 301/307 redirects
@@ -22,7 +22,7 @@ actor JsonRequester is courier.HTTPClientConnectionActor
   var _http: courier.HTTPClientConnection = courier.HTTPClientConnection.none()
   var _collector: courier.ResponseCollector = courier.ResponseCollector
   let _creds: Credentials
-  let _receiver: JsonRequesterResultReceiver
+  let _receiver: JSONRequesterResultReceiver
   let _method: courier.Method
   let _expected_status: U16
   let _body: (String | None)
@@ -32,7 +32,7 @@ actor JsonRequester is courier.HTTPClientConnectionActor
 
   new get(creds: Credentials,
     url: String,
-    receiver: JsonRequesterResultReceiver)
+    receiver: JSONRequesterResultReceiver)
   =>
     """
     Issues an HTTP GET request expecting a 200 response with a JSON body.
@@ -47,7 +47,7 @@ actor JsonRequester is courier.HTTPClientConnectionActor
   new post(creds: Credentials,
     url: String,
     body: String,
-    receiver: JsonRequesterResultReceiver)
+    receiver: JSONRequesterResultReceiver)
   =>
     """
     Issues an HTTP POST request expecting a 201 response with a JSON body.
@@ -62,7 +62,7 @@ actor JsonRequester is courier.HTTPClientConnectionActor
   new patch(creds: Credentials,
     url: String,
     body: String,
-    receiver: JsonRequesterResultReceiver)
+    receiver: JSONRequesterResultReceiver)
   =>
     """
     Issues an HTTP PATCH request expecting a 200 response with a JSON body.
@@ -136,7 +136,7 @@ actor JsonRequester is courier.HTTPClientConnectionActor
       | let loc: String =>
         _redirected = true
         _http.close()
-        JsonRequester.get(_creds, loc, _receiver)
+        JSONRequester.get(_creds, loc, _receiver)
         return
       end
     end
@@ -153,9 +153,9 @@ actor JsonRequester is courier.HTTPClientConnectionActor
       let response = _collector.build()?
       if _status == _expected_status then
         match \exhaustive\ courier.ResponseJSON(response)
-        | let json: JsonValue =>
-          _receiver.success(JsonNav(json))
-        | let _: JsonParseError =>
+        | let json: JSONValue =>
+          _receiver.success(JSONNav(json))
+        | let _: JSONParseError =>
           _receiver.failure(_status, "", "Failed to parse response")
         end
       else

--- a/github_rest_api/search.pony
+++ b/github_rest_api/search.pony
@@ -40,7 +40,7 @@ class val SearchResults[A: Any val]
   let items: Array[A] val
 
   new val _create(creds: req.Credentials,
-    converter: req.JsonConverter[A],
+    converter: req.JSONConverter[A],
     total_count': I64,
     incomplete_results': Bool,
     items': Array[A] val,
@@ -91,13 +91,13 @@ class val PaginatedSearchJsonConverter[A: Any val]
   and `items` fields) plus Link header pagination into SearchResults.
   """
   let _creds: req.Credentials
-  let _converter: req.JsonConverter[A]
+  let _converter: req.JSONConverter[A]
 
-  new val create(creds: req.Credentials, converter: req.JsonConverter[A]) =>
+  new val create(creds: req.Credentials, converter: req.JSONConverter[A]) =>
     _creds = creds
     _converter = converter
 
-  fun apply(json: JsonNav,
+  fun apply(json: JSONNav,
     link_header: String,
     creds: req.Credentials): SearchResults[A] ?
   =>
@@ -106,7 +106,7 @@ class val PaginatedSearchJsonConverter[A: Any val]
 
     let items = recover trn Array[A] end
     for i in json("items").as_array()?.values() do
-      let item = _converter(JsonNav(i), creds)?
+      let item = _converter(JSONNav(i), creds)?
       items.push(item)
     end
 
@@ -137,12 +137,12 @@ actor SearchResultReceiver[A: Any val]
     _p = p
     _converter = c
 
-  be success(json: JsonNav, link_header: String) =>
+  be success(json: JSONNav, link_header: String) =>
     try
       _p(_converter(json, link_header, _creds)?)
     else
       let m = recover val
-        "Unable to convert json for " + req.JsonTypeString(json)
+        "Unable to convert json for " + req.JSONTypeString(json)
       end
 
       _p(req.RequestError(where message' = m))

--- a/github_rest_api/user.pony
+++ b/github_rest_api/user.pony
@@ -67,11 +67,11 @@ class val User
     user_type = user_type'
     site_admin = site_admin'
 
-primitive UserJsonConverter is req.JsonConverter[User]
+primitive UserJsonConverter is req.JSONConverter[User]
   """
   Converts a JSON object into a User.
   """
-  fun apply(json: JsonNav, creds: req.Credentials): User ? =>
+  fun apply(json: JSONNav, creds: req.Credentials): User ? =>
     let login = json("login").as_string()?
     let id = json("id").as_i64()?
     let node_id = json("node_id").as_string()?


### PR DESCRIPTION
Rename all Json* types to JSON* per the ponyc json-package rename, bump courier to 0.7.0 (which has the same rename), declare ponyc 0.69.1 as the minimum required version, add a nightly-lint job to the breakage workflow, and switch pr.yml to nightly.